### PR TITLE
feat(ai-provider): 添加稀宇科技 MiniMax 作为新的 AI 提供商

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3069,6 +3069,15 @@ pub async fn get_ai_providers() -> Result<Vec<serde_json::Value>, AppError> {
             "requires_api_key": true,
             "supports_vision": false,
         }),
+        serde_json::json!({
+            "id": "minimax",
+            "name": "稀宇科技 MiniMax",
+            "description": "稀宇科技大语言模型",
+            "default_endpoint": "https://api.minimax.chat/v1",
+            "default_model": "MiniMax-M2.5",
+            "requires_api_key": true,
+            "supports_vision": false,
+        }),
     ])
 }
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -34,6 +34,9 @@ pub enum AiProvider {
     /// 火山引擎 豆包
     #[serde(rename = "doubao")]
     Doubao,
+    /// 稀宇科技 MiniMax
+    #[serde(rename = "minimax")]
+    MiniMax,
 }
 
 impl AiProvider {
@@ -50,6 +53,7 @@ impl AiProvider {
             AiProvider::Zhipu => "智谱 ChatGLM",
             AiProvider::Moonshot => "月之暗面 Kimi",
             AiProvider::Doubao => "火山引擎 豆包",
+            AiProvider::MiniMax => "稀宇科技 MiniMax",
         }
     }
 
@@ -66,6 +70,7 @@ impl AiProvider {
             AiProvider::Zhipu => "https://open.bigmodel.cn/api/paas/v4",
             AiProvider::Moonshot => "https://api.moonshot.cn/v1",
             AiProvider::Doubao => "https://ark.cn-beijing.volces.com/api/v3",
+            AiProvider::MiniMax => "https://api.minimax.chat/v1",
         }
     }
 
@@ -82,6 +87,7 @@ impl AiProvider {
             AiProvider::Zhipu => "glm-4-flash",
             AiProvider::Moonshot => "moonshot-v1-8k",
             AiProvider::Doubao => "doubao-lite-4k",
+            AiProvider::MiniMax => "MiniMax-Text-01",
         }
     }
 
@@ -96,6 +102,7 @@ impl AiProvider {
                 | AiProvider::Zhipu
                 | AiProvider::Moonshot
                 | AiProvider::Doubao
+                | AiProvider::MiniMax
         )
     }
 }


### PR DESCRIPTION
在 AI 提供商列表和配置中添加 MiniMax 支持，包括默认端点、模型和显示名称

<img width="1250" height="874" alt="image" src="https://github.com/user-attachments/assets/320186ee-2b5b-4f39-a6c2-daa1cad4c30d" />
