### PR TITLE
fix: 修复 max_output_tokens 过小及跨零点工作时长统计异常

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3015,7 +3015,7 @@ async fn test_openai(
         .json(&serde_json::json!({
             "model": config.model,
             "messages": [{"role": "user", "content": "Hello"}],
-            "max_tokens": 5,
+            "max_tokens": 16,
         }))
         .send()
         .await

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1069,6 +1069,14 @@ impl Database {
             if work_end_ts > work_start_ts {
                 work_time_duration +=
                     calculate_overlap_duration(timestamp, duration, work_start_ts, work_end_ts);
+            } else {
+                // 跨零点：结束时间在次日，加一天偏移后计算重叠
+                work_time_duration += calculate_overlap_duration(
+                    timestamp,
+                    duration,
+                    work_start_ts,
+                    work_end_ts + 86400,
+                );
             }
 
             let interval_start = timestamp.saturating_sub(duration);

--- a/src/routes/settings/components/SettingsGeneral.svelte
+++ b/src/routes/settings/components/SettingsGeneral.svelte
@@ -45,8 +45,9 @@
     currentLocale;
     const startTotal = startHour * 60 + startMinute;
     const endTotal = endHour * 60 + endMinute;
-    const diffSeconds = (endTotal - startTotal) * 60;
-    workHours = diffSeconds <= 0 ? '—' : formatDurationLocalized(diffSeconds);
+    const diffMinutes = endTotal - startTotal;
+    const adjustedMinutes = diffMinutes <= 0 ? diffMinutes + 24 * 60 : diffMinutes;
+    workHours = formatDurationLocalized(adjustedMinutes * 60);
   }
 
   function updateStart(h, m) {


### PR DESCRIPTION
  ## 修复内容

  ### 问题一：第三方 OpenAI 兼容 API 报错（fixes #41）

  连接测试接口中 `max_tokens` 硬编码为 `5`，低于部分第三方 API 的最小值要求（如七牛云要求 ≥16），导致测试请求直接报错。

  **改动：** `src-tauri/src/commands.rs` 中将 `max_tokens: 5` 调整为 `max_tokens: 16`。

  ### 问题二：工作时段跨零点时时长显示异常（fixes #42）

  当工作结束时间早于开始时间（如 22:00 ~ 02:00）时：
  - 后端 `database.rs` 中 `work_end_ts < work_start_ts` 导致判断条件不成立，整段办公时长统计被跳过，记录为 0
  - 前端设置页计算出负数秒数，直接显示为 `—`

  **改动：**
  - `src-tauri/src/database.rs`：补充 `else` 分支，跨零点时对结束时间加 86400 秒（一天）后再计算重叠时长
  - `src/routes/settings/components/SettingsGeneral.svelte`：跨零点时对分钟差补加 24×60，正确显示时长

  ## 改动范围

  本次修改仅涉及以上三处最小化变更，不影响其他逻辑。

  ---
  > by Claude Code · model claude-sonnet-4-5