### PR TITLE
fix: safely catch autostart toggle errors to prevent UI desync

### DIFF
--- a/src/routes/settings/components/SettingsGeneral.svelte
+++ b/src/routes/settings/components/SettingsGeneral.svelte
@@ -86,7 +86,7 @@
       autoStartEnabled = await invoke('is_autostart_enabled');
       config.auto_start = autoStartEnabled;
       dispatch('change', config);
-    } catch(e) {
+    } catch (e) {
       console.error('重新校验开机自启状态失败:', e);
     }
   }

--- a/src/routes/settings/components/SettingsGeneral.svelte
+++ b/src/routes/settings/components/SettingsGeneral.svelte
@@ -72,18 +72,22 @@
 
   // 开机自启动切换
   async function toggleAutoStart() {
+    const targetState = !autoStartEnabled;
     try {
-      autoStartEnabled = await invoke('is_autostart_enabled');
-      if (autoStartEnabled) {
-        await invoke('disable_autostart');
-      } else {
+      if (targetState) {
         await invoke('enable_autostart');
+      } else {
+        await invoke('disable_autostart');
       }
+    } catch (e) {
+      console.warn(`切换系统自启失败/警告 (目标状态: ${targetState}):`, e);
+    }
+    try {
       autoStartEnabled = await invoke('is_autostart_enabled');
       config.auto_start = autoStartEnabled;
       dispatch('change', config);
-    } catch (e) {
-      console.error('设置开机自启动失败:', e);
+    } catch(e) {
+      console.error('重新校验开机自启状态失败:', e);
     }
   }
 


### PR DESCRIPTION
## 背景

这个 PR 是针对 Windows 环境下自启动开关抛出异常导致 UI 可视状态不同步的修复。

在某些 Windows 系统中，前端调用 Rust 后端的 disable_autostart 命令时，虽然实际上成功清理了注册表项，但 Windows 底层 API 仍会抛出 os error -2147024891 (0x80070005 E_ACCESSDENIED) 错误。
原有的前端逻辑如果不能妥善吞下并处理这个异常，会直接阻断后续的数据赋值流程。结果是：系统自启实际已被关闭，但 UI 开关仍然卡在“开启”状态，导致严重的用户困惑。

## 本次调整

- **重构自启动切换逻辑**：在 SettingsGeneral.svelte 的 toggleAutoStart 函数中，将 enable_autostart / disable_autostart 的执行放进独立的 try/catch。
- **异常降级为警告**：如果调用抛出异常，仅通过 console.warn 记录告警，绝不中断后续流程。
- **基于系统真实状态更新 UI**：不再依赖调用的成功与否去推测结果，而是无论中间是否报错，最后统一再次调用 is_autostart_enabled 校验当前真实的系统状态，并以此更新前端配置和分发事件。

## 为什么这么改

- 当前这种“触发操作 -> 忽略操作带来的边缘报错 -> 重新拉取一次真实验证值并渲染”的模式，比多层嵌套和过度判断更直接、更健壮。
- 这样改动可以最大化保障 UX 层面的体验一致性，彻底告别 UI 假死或状态割裂，且跨平台兼容。

## 验证

- Windows 注册表人工复核：观察到抛错时，目标键值确实已被正确删除。
- UI 可视状态已经同步
- 正常的编译与前端构建流程。

<img width="1250" height="948" alt="PixPin_2026-04-18_23-40-48" src="https://github.com/user-attachments/assets/d8371435-ff9f-4db6-b1f9-d1bb9d530e54" />
<img width="1562" height="767" alt="PixPin_2026-04-18_23-43-19" src="https://github.com/user-attachments/assets/75422ac8-5c00-4653-9f5a-cc985dcdb745" />

## 关联

- Related: #50
- Related: #53
- Related: tauri-apps/plugins-workspace#1922