### PR TITLE
feat(ai): add Atlas Cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The core of Work Review is always **local recording**. AI's role is to make reco
 | **Basic Template** | Zero configuration, outputs stable structured results |
 | **AI Enhanced** | Calls your self-configured model service for more natural Q&A and summaries |
 
-Supported providers: Ollama (local) / LM Studio (local) / OpenAI compatible / DeepSeek / Qwen / Zhipu / Kimi / Doubao / MiniMax / SiliconFlow / Gemini / Claude / OpenRouter / Groq / xAI Grok / Mistral / Custom endpoint
+Supported providers: Ollama (local) / LM Studio (local) / OpenAI compatible / Atlas Cloud / DeepSeek / Qwen / Zhipu / Kimi / Doubao / MiniMax / SiliconFlow / Gemini / Claude / OpenRouter / Groq / xAI Grok / Mistral / Custom endpoint
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -197,7 +197,7 @@ Work Review 的核心始终是**本地记录**。AI 的作用是让记录更容�
 | **基础模板** | 零配置，输出稳定的结构化结果 |
 | **AI 增强** | 调用你自行配置的模型服务，让问答和总结更自然 |
 
-支持的提供商：Ollama (本地) / LM Studio (本地) / OpenAI 兼容 / DeepSeek / 通义千问 / 智谱 / Kimi / 豆包 / MiniMax / SiliconFlow / Gemini / Claude / OpenRouter / Groq / xAI Grok / Mistral / 自定义接口
+支持的提供商：Ollama (本地) / LM Studio (本地) / OpenAI 兼容 / Atlas Cloud / DeepSeek / 通义千问 / 智谱 / Kimi / 豆包 / MiniMax / SiliconFlow / Gemini / Claude / OpenRouter / Groq / xAI Grok / Mistral / 自定义接口
 
 ---
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -23,6 +23,9 @@ pub enum AiProvider {
     Ollama,
     /// OpenAI / OpenAI Compatible
     OpenAI,
+    /// Atlas Cloud (OpenAI Compatible)
+    #[serde(rename = "atlascloud")]
+    AtlasCloud,
     /// Google Gemini
     Gemini,
     /// Anthropic Claude
@@ -80,6 +83,7 @@ impl AiProvider {
         match self {
             AiProvider::Ollama => "Ollama (本地)",
             AiProvider::OpenAI => "OpenAI / 兼容API",
+            AiProvider::AtlasCloud => "Atlas Cloud",
             AiProvider::Gemini => "Google Gemini",
             AiProvider::Claude => "Anthropic Claude",
             AiProvider::SiliconFlow => "硅基流动 SiliconFlow",
@@ -103,6 +107,7 @@ impl AiProvider {
         match self {
             AiProvider::Ollama => "http://localhost:11434",
             AiProvider::OpenAI => "https://api.openai.com/v1",
+            AiProvider::AtlasCloud => "https://api.atlascloud.ai/v1",
             AiProvider::Gemini => "https://generativelanguage.googleapis.com/v1",
             AiProvider::Claude => "https://api.anthropic.com/v1",
             AiProvider::SiliconFlow => "https://api.siliconflow.cn/v1",
@@ -126,6 +131,7 @@ impl AiProvider {
         match self {
             AiProvider::Ollama => "qwen3",
             AiProvider::OpenAI => "gpt-5.4",
+            AiProvider::AtlasCloud => "deepseek-ai/deepseek-v4-pro",
             AiProvider::Gemini => "gemini-3-flash",
             AiProvider::Claude => "claude-sonnet-4-6",
             AiProvider::SiliconFlow => "Qwen/Qwen3-8B",
@@ -149,6 +155,7 @@ impl AiProvider {
         matches!(
             self,
             AiProvider::OpenAI
+                | AiProvider::AtlasCloud
                 | AiProvider::SiliconFlow
                 | AiProvider::DeepSeek
                 | AiProvider::Qwen
@@ -2557,6 +2564,19 @@ mod tests {
             "https://api.minimaxi.com/v1"
         );
         assert_eq!(AiProvider::MiniMax.default_model(), "MiniMax-M2.5");
+    }
+
+    #[test]
+    fn atlas_cloud应使用_openai_兼容配置() {
+        assert!(AiProvider::AtlasCloud.is_openai_compatible());
+        assert_eq!(
+            AiProvider::AtlasCloud.default_endpoint(),
+            "https://api.atlascloud.ai/v1"
+        );
+        assert_eq!(
+            AiProvider::AtlasCloud.default_model(),
+            "deepseek-ai/deepseek-v4-pro"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -867,6 +867,15 @@ pub async fn get_ai_providers() -> Result<Vec<serde_json::Value>, AppError> {
             "supports_vision": false,
         }),
         serde_json::json!({
+            "id": "atlascloud",
+            "name": "Atlas Cloud",
+            "description": "OpenAI 兼容的多模型文本推理 API",
+            "default_endpoint": "https://api.atlascloud.ai/v1",
+            "default_model": "deepseek-ai/deepseek-v4-pro",
+            "requires_api_key": true,
+            "supports_vision": false,
+        }),
+        serde_json::json!({
             "id": "siliconflow",
             "name": "硅基流动 SiliconFlow",
             "description": "国内高性价比 API，兼容 OpenAI 格式",

--- a/src/AiProviders.test.js
+++ b/src/AiProviders.test.js
@@ -52,3 +52,28 @@ test('应提供 OpenRouter/Groq/xAI/Mistral/LM Studio/自定义 六个新提供�
   assert.match(settingsSource, /providerIconFailed/);
   assert.match(settingsSource, /icons\/providers/);
 });
+
+test('应提供 Atlas Cloud OpenAI 兼容提供商并同步技术清单', async () => {
+  const [configSource, commandSource, readmeSource, readmeEnSource, settingsSource, askSource] =
+    await Promise.all([
+      readFile(new URL('../crates/core/src/config.rs', import.meta.url), 'utf8'),
+      readCommandsSource(),
+      readFile(new URL('../README.zh.md', import.meta.url), 'utf8'),
+      readFile(new URL('../README.md', import.meta.url), 'utf8'),
+      readFile(
+        new URL('./routes/settings/components/SettingsAI.svelte', import.meta.url),
+        'utf8'
+      ),
+      readFile(new URL('./routes/ask/Ask.svelte', import.meta.url), 'utf8'),
+    ]);
+
+  assert.match(configSource, /AtlasCloud/);
+  assert.match(configSource, /https:\/\/api\.atlascloud\.ai\/v1/);
+  assert.match(configSource, /deepseek-ai\/deepseek-v4-pro/);
+  assert.match(configSource, /AiProvider::AtlasCloud[\s\S]*?AiProvider::Custom[\s\S]*?\)\s*\}/);
+  assert.match(commandSource, /"id": "atlascloud"/);
+  assert.match(settingsSource, /atlascloud:/);
+  assert.match(askSource, /atlascloud:/);
+  assert.match(readmeSource, /Atlas Cloud/);
+  assert.match(readmeEnSource, /Atlas Cloud/);
+});

--- a/src/routes/ask/Ask.svelte
+++ b/src/routes/ask/Ask.svelte
@@ -51,6 +51,7 @@
       en: 'OpenAI Compatible',
       'zh-TW': 'OpenAI 相容',
     },
+    atlascloud: { 'zh-CN': 'Atlas Cloud', en: 'Atlas Cloud', 'zh-TW': 'Atlas Cloud' },
     siliconflow: {
       'zh-CN': '硅基流动',
       en: 'SiliconFlow',

--- a/src/routes/settings/components/SettingsAI.svelte
+++ b/src/routes/settings/components/SettingsAI.svelte
@@ -93,6 +93,11 @@
       en: { name: 'OpenAI / Compatible', description: 'Official OpenAI and compatible endpoints (Azure, Cloudflare, etc.)' },
       'zh-TW': { name: 'OpenAI / 相容 API', description: '支援官方與相容端點（Azure、Cloudflare 等）' },
     },
+    atlascloud: {
+      'zh-CN': { name: 'Atlas Cloud', description: 'OpenAI 兼容的多模型文本推理 API' },
+      en: { name: 'Atlas Cloud', description: 'Multi-model text inference with an OpenAI-compatible API' },
+      'zh-TW': { name: 'Atlas Cloud', description: '支援 OpenAI 相容格式的多模型文字推論 API' },
+    },
     siliconflow: {
       'zh-CN': { name: '硅基流动 SiliconFlow', description: '国内高性价比 API' },
       en: { name: 'SiliconFlow', description: 'Cost-effective domestic API' },
@@ -250,6 +255,7 @@
   const PROVIDER_BRAND = {
     ollama: '#111827',
     openai: '#10a37f',
+    atlascloud: '#2563eb',
     siliconflow: '#6e4ff6',
     deepseek: '#4d6bfe',
     qwen: '#615ced',


### PR DESCRIPTION
## Summary

- add Atlas Cloud as a built-in OpenAI-compatible AI provider
- prefill `https://api.atlascloud.ai/v1` and `deepseek-ai/deepseek-v4-pro` in the provider selector
- expose localized provider labels in Settings and Ask model profiles
- add Rust and source-contract regression coverage
- update the existing English and Chinese supported-provider lists

## Validation

- `node --test` (352 passed)
- `cargo test -p work-review-core atlas_cloud --lib` (1 passed)
- `npm run build` (passed; two existing unused-export warnings in unchanged node gateway components)
- `git diff --check`
- Atlas Cloud live `GET /v1/models`: HTTP 200, 121 models; configured default model present

## Formatting note

- `cargo fmt --all -- --check` reports broad pre-existing formatting drift across many unchanged Rust files. This PR keeps its Rust additions locally aligned with the surrounding style and does not apply unrelated repository-wide formatting changes.

README changes are limited to the existing technical provider list. No logo, sponsor, credits, or partner content was added.