### PR TITLE
feat(demo): add verified 85-second product video pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ src-tauri/icons.backup/
 /plan.md
 .claude/
 .zcode/
+
+# 产品演示生成产物
+/artifacts/product-demo/

--- a/package.json
+++ b/package.json
@@ -20,7 +20,14 @@
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
-    "tauri:build:local-mac": "tauri build --target aarch64-apple-darwin --bundles app --config src-tauri/tauri.local.conf.json"
+    "tauri:build:local-mac": "tauri build --target aarch64-apple-darwin --bundles app --config src-tauri/tauri.local.conf.json",
+    "demo:check": "node --test-timeout=60000 --import tsx --test \"scripts/product-demo/*.test.ts\"",
+    "demo:capture": "node --import tsx scripts/product-demo/cli.ts capture",
+    "demo:subtitles": "node --import tsx scripts/product-demo/cli.ts subtitles",
+    "demo:audio": "node --import tsx scripts/product-demo/cli.ts audio",
+    "demo:compose": "node --import tsx scripts/product-demo/cli.ts compose",
+    "demo:validate": "node --import tsx scripts/product-demo/cli.ts validate",
+    "demo:build": "node --import tsx scripts/product-demo/cli.ts build"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.0.0",

--- a/scripts/product-demo/audio.ts
+++ b/scripts/product-demo/audio.ts
@@ -1,0 +1,436 @@
+import { mkdir } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import type { StoryboardCue } from './types.ts';
+import { DEMO_DURATION_SECONDS } from './storyboard.ts';
+import {
+  buildLoudnormAnalysisArgs,
+  buildLoudnormRenderArgs,
+  discoverMediaBinaries,
+  parseLoudnormMeasurement,
+  probeMedia,
+  runCommand,
+  type CommandResult,
+  type CommandRunner,
+  type MediaProbe,
+} from './ffmpeg.ts';
+
+export const AUDIO_SAMPLE_RATE = 48_000;
+export const AUDIO_CHANNELS = 2;
+export const LAST_VOICEOVER_END_SECONDS = 83;
+const DUCKING_GAIN = 0.316228; // -10 dB，位于规格要求的 8–12 dB 范围内。
+const TRUE_PEAK_LIMIT = 0.891251; // -1 dBFS，最终仍会再做两遍 loudnorm。
+
+export interface CommandDescription {
+  binary: string;
+  args: string[];
+}
+
+export interface VoiceoverInput {
+  path: string;
+  startSeconds: number;
+}
+
+export type SoundEffectKind = 'click' | 'switch' | 'complete' | 'outro';
+
+export interface SoundEffectCue {
+  kind: SoundEffectKind;
+  atSeconds: number;
+  frequency: number;
+  durationSeconds: number;
+  gain: number;
+}
+
+export const DEFAULT_SOUND_EFFECTS: readonly SoundEffectCue[] = [
+  { kind: 'click', atSeconds: 8.4, frequency: 880, durationSeconds: 0.09, gain: 0.08 },
+  { kind: 'switch', atSeconds: 41.2, frequency: 660, durationSeconds: 0.16, gain: 0.07 },
+  { kind: 'complete', atSeconds: 29.4, frequency: 990, durationSeconds: 0.28, gain: 0.075 },
+  { kind: 'outro', atSeconds: 78.4, frequency: 523.25, durationSeconds: 0.8, gain: 0.055 },
+] as const;
+
+export interface AudioExecutionOptions {
+  ffmpegPath?: string;
+  runner?: CommandRunner;
+}
+
+export interface BuildVoiceoverOptions extends AudioExecutionOptions {
+  outputDir: string;
+  ffprobePath?: string;
+  probe?: (mediaPath: string) => Promise<MediaProbe>;
+}
+
+export interface MixDemoAudioOptions extends AudioExecutionOptions {
+  voiceoverPath: string;
+  musicPath: string;
+  effectsPath: string;
+  outputPath: string;
+  voiceoverCues: readonly StoryboardCue[];
+}
+
+export interface BuildAudioMixOptions {
+  voiceoverPath: string;
+  musicPath: string;
+  effectsPath: string;
+  outputPath: string;
+  voiceoverCues: readonly StoryboardCue[];
+}
+
+function assertPath(value: string, label: string): void {
+  if (!value.trim()) throw new Error(`${label}不能为空`);
+}
+
+function assertFiniteTime(value: number, label: string): void {
+  if (!Number.isFinite(value) || value < 0) throw new Error(`${label}必须是非负有限数`);
+}
+
+function formatSeconds(value: number): string {
+  return value.toFixed(3);
+}
+
+function milliseconds(value: number): number {
+  return Math.round(value * 1000);
+}
+
+function pcmOutputArgs(outputPath: string): string[] {
+  return [
+    '-ar', String(AUDIO_SAMPLE_RATE),
+    '-ac', String(AUDIO_CHANNELS),
+    '-c:a', 'pcm_s24le',
+    '-t', DEMO_DURATION_SECONDS.toFixed(3),
+    outputPath,
+  ];
+}
+
+async function resolveFfmpegPath(options: AudioExecutionOptions): Promise<string> {
+  if (options.ffmpegPath) return options.ffmpegPath;
+  return (await discoverMediaBinaries({ runner: options.runner })).ffmpeg;
+}
+
+export function buildSayVoiceListCommand(): CommandDescription {
+  return { binary: '/usr/bin/say', args: ['-v', '?'] };
+}
+
+export function hasTingtingVoice(voiceList: string): boolean {
+  return voiceList
+    .split(/\r?\n/)
+    .some((line) => /^\s*Tingting\s+/i.test(line) && /\bzh[_-]CN\b/i.test(line));
+}
+
+export function buildSayCommand(text: string, outputPath: string): CommandDescription {
+  if (!text.trim()) throw new Error('旁白文本不能为空');
+  assertPath(outputPath, '旁白 AIFF 输出路径');
+  return {
+    binary: '/usr/bin/say',
+    args: ['-v', 'Tingting', '-o', outputPath, text],
+  };
+}
+
+export async function runSayCommand(
+  command: CommandDescription,
+  runner: CommandRunner = runCommand,
+): Promise<CommandResult> {
+  if (command.binary !== '/usr/bin/say') throw new Error('旁白命令必须使用 /usr/bin/say');
+  return runner(command.binary, command.args);
+}
+
+export function buildVoiceoverConversionArgs(inputPath: string, outputPath: string): string[] {
+  assertPath(inputPath, '旁白 AIFF 输入路径');
+  assertPath(outputPath, '旁白 WAV 输出路径');
+  return [
+    '-hide_banner',
+    '-nostdin',
+    '-y',
+    '-i', inputPath,
+    '-vn',
+    '-ar', String(AUDIO_SAMPLE_RATE),
+    '-ac', String(AUDIO_CHANNELS),
+    '-c:a', 'pcm_s24le',
+    outputPath,
+  ];
+}
+
+export function buildVoiceoverMixArgs(
+  inputs: readonly VoiceoverInput[],
+  outputPath: string,
+): string[] {
+  if (inputs.length === 0) throw new Error('旁白混音至少需要一个输入');
+  assertPath(outputPath, '旁白混音输出路径');
+
+  const args = ['-hide_banner', '-nostdin', '-y'];
+  for (const input of inputs) {
+    assertPath(input.path, '旁白片段路径');
+    assertFiniteTime(input.startSeconds, '旁白开始时间');
+    args.push('-i', input.path);
+  }
+
+  const chains = inputs.map((input, index) => {
+    const delay = milliseconds(input.startSeconds);
+    return `[${index}:a]aformat=sample_rates=${AUDIO_SAMPLE_RATE}:channel_layouts=stereo,adelay=${delay}|${delay}[voice${index}]`;
+  });
+  const labels = inputs.map((_, index) => `[voice${index}]`).join('');
+  chains.push(
+    `${labels}amix=inputs=${inputs.length}:normalize=0:duration=longest,`
+      + `atrim=0:${DEMO_DURATION_SECONDS},apad=whole_dur=${DEMO_DURATION_SECONDS}[voiceout]`,
+  );
+
+  args.push(
+    '-filter_complex', chains.join(';'),
+    '-map', '[voiceout]',
+    ...pcmOutputArgs(outputPath),
+  );
+  return args;
+}
+
+function safeCueFileStem(index: number, cue: StoryboardCue): string {
+  const safeId = cue.id.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || 'cue';
+  return `${String(index + 1).padStart(2, '0')}-${safeId}`;
+}
+
+function validateVoiceoverCue(cue: StoryboardCue): void {
+  assertFiniteTime(cue.start, `旁白 ${cue.id} 开始时间`);
+  assertFiniteTime(cue.end, `旁白 ${cue.id} 结束时间`);
+  if (cue.end <= cue.start) throw new Error(`旁白 ${cue.id} 的结束时间必须晚于开始时间`);
+  if (!cue.zh.trim()) throw new Error(`旁白 ${cue.id} 缺少中文文本`);
+}
+
+export async function buildVoiceover(
+  cues: readonly StoryboardCue[],
+  options: BuildVoiceoverOptions,
+): Promise<string> {
+  if (cues.length === 0) throw new Error('至少需要一条中文旁白');
+  assertPath(options.outputDir, '旁白输出目录');
+  await mkdir(options.outputDir, { recursive: true });
+
+  const runner = options.runner ?? runCommand;
+  const voiceListCommand = buildSayVoiceListCommand();
+  const voiceList = await runner(voiceListCommand.binary, voiceListCommand.args);
+  if (!hasTingtingVoice(voiceList.stdout)) {
+    throw new Error('系统未提供中文 Tingting 语音，无法生成批准的演示旁白');
+  }
+
+  let ffmpegPath = options.ffmpegPath;
+  let ffprobePath = options.ffprobePath;
+  if (!ffmpegPath || (!ffprobePath && !options.probe)) {
+    const binaries = await discoverMediaBinaries({ runner });
+    ffmpegPath ??= binaries.ffmpeg;
+    ffprobePath ??= binaries.ffprobe;
+  }
+
+  const probe = options.probe ?? ((mediaPath: string) => probeMedia(mediaPath, {
+    ffprobePath,
+    runner,
+  }));
+  const mixInputs: VoiceoverInput[] = [];
+
+  for (const [index, cue] of cues.entries()) {
+    validateVoiceoverCue(cue);
+    const stem = safeCueFileStem(index, cue);
+    const aiffPath = join(options.outputDir, `${stem}.aiff`);
+    const wavPath = join(options.outputDir, `${stem}.wav`);
+    await runSayCommand(buildSayCommand(cue.zh, aiffPath), runner);
+    await runner(ffmpegPath, buildVoiceoverConversionArgs(aiffPath, wavPath));
+
+    const media = await probe(wavPath);
+    const actualDuration = media.audio?.durationSeconds ?? media.durationSeconds;
+    if (actualDuration === null || !Number.isFinite(actualDuration)) {
+      throw new Error(`无法确定旁白 ${cue.id} 的实际时长`);
+    }
+    const deadline = index === cues.length - 1
+      ? Math.min(cue.end, LAST_VOICEOVER_END_SECONDS)
+      : cue.end;
+    const availableDuration = deadline - cue.start;
+    if (availableDuration <= 0) {
+      throw new Error(`旁白 ${cue.id} 没有可用时间，必须在 ${formatSeconds(deadline)} 秒前结束`);
+    }
+    if (actualDuration > availableDuration) {
+      throw new Error(
+        `旁白 ${cue.id} 实际 ${formatSeconds(actualDuration)} 秒，超过可用的 `
+          + `${formatSeconds(availableDuration)} 秒；必须在 ${formatSeconds(deadline)} 秒前结束，`
+          + '不会通过强制加速降低可懂度。',
+      );
+    }
+    mixInputs.push({ path: wavPath, startSeconds: cue.start });
+  }
+
+  const outputPath = join(options.outputDir, 'voiceover.wav');
+  await runner(ffmpegPath, buildVoiceoverMixArgs(mixInputs, outputPath));
+  return outputPath;
+}
+
+export function buildBackgroundMusicArgs(outputPath: string): string[] {
+  assertPath(outputPath, '背景音乐输出路径');
+  const args = ['-hide_banner', '-nostdin', '-y'];
+  const tones = [110, 164.81, 220];
+  for (const frequency of tones) {
+    args.push(
+      '-f', 'lavfi',
+      '-i', `sine=frequency=${frequency}:sample_rate=${AUDIO_SAMPLE_RATE}:duration=${DEMO_DURATION_SECONDS}`,
+    );
+  }
+
+  const filter = [
+    '[0:a]volume=0.035[base]',
+    '[1:a]volume=0.020[mid]',
+    '[2:a]volume=0.012[air]',
+    '[base][mid][air]amix=inputs=3:normalize=0:duration=longest,'
+      + 'lowpass=f=1200,highpass=f=70,aformat=sample_rates=48000:channel_layouts=stereo,'
+      + `afade=t=in:st=0:d=2,afade=t=out:st=80:d=5,atrim=0:${DEMO_DURATION_SECONDS}[musicout]`,
+  ].join(';');
+
+  args.push(
+    '-filter_complex', filter,
+    '-map', '[musicout]',
+    ...pcmOutputArgs(outputPath),
+  );
+  return args;
+}
+
+export async function buildBackgroundMusic(
+  outputPath: string,
+  options: AudioExecutionOptions = {},
+): Promise<string> {
+  await mkdir(dirname(outputPath), { recursive: true });
+  const runner = options.runner ?? runCommand;
+  const ffmpegPath = await resolveFfmpegPath(options);
+  await runner(ffmpegPath, buildBackgroundMusicArgs(outputPath));
+  return outputPath;
+}
+
+function validateSoundEffect(effect: SoundEffectCue): void {
+  assertFiniteTime(effect.atSeconds, `${effect.kind} 音效时间`);
+  if (!Number.isFinite(effect.frequency) || effect.frequency <= 0) {
+    throw new Error(`${effect.kind} 音效频率必须是正有限数`);
+  }
+  if (!Number.isFinite(effect.durationSeconds) || effect.durationSeconds <= 0) {
+    throw new Error(`${effect.kind} 音效时长必须是正有限数`);
+  }
+  if (!Number.isFinite(effect.gain) || effect.gain <= 0 || effect.gain > 1) {
+    throw new Error(`${effect.kind} 音效增益必须位于 0 到 1 之间`);
+  }
+  if (effect.atSeconds + effect.durationSeconds > DEMO_DURATION_SECONDS) {
+    throw new Error(`${effect.kind} 音效超过 ${DEMO_DURATION_SECONDS} 秒时间线`);
+  }
+}
+
+export function buildSoundEffectsArgs(
+  effects: readonly SoundEffectCue[],
+  outputPath: string,
+): string[] {
+  if (effects.length === 0) throw new Error('至少需要一个程序化音效');
+  assertPath(outputPath, '音效输出路径');
+  const args = ['-hide_banner', '-nostdin', '-y'];
+
+  for (const effect of effects) {
+    validateSoundEffect(effect);
+    args.push(
+      '-f', 'lavfi',
+      '-i', `sine=frequency=${effect.frequency}:sample_rate=${AUDIO_SAMPLE_RATE}:duration=${effect.durationSeconds}`,
+    );
+  }
+
+  const chains = effects.map((effect, index) => {
+    const fadeStart = Math.max(0, effect.durationSeconds - Math.min(0.12, effect.durationSeconds / 2));
+    const fadeDuration = effect.durationSeconds - fadeStart;
+    const delay = milliseconds(effect.atSeconds);
+    return `[${index}:a]volume=${effect.gain},afade=t=out:st=${formatSeconds(fadeStart)}:`
+      + `d=${formatSeconds(fadeDuration)},aformat=sample_rates=48000:channel_layouts=stereo,`
+      + `adelay=${delay}|${delay}[effect${index}]`;
+  });
+  const labels = effects.map((_, index) => `[effect${index}]`).join('');
+  chains.push(
+    `${labels}amix=inputs=${effects.length}:normalize=0:duration=longest,`
+      + `atrim=0:${DEMO_DURATION_SECONDS},apad=whole_dur=${DEMO_DURATION_SECONDS}[effectsout]`,
+  );
+
+  args.push(
+    '-filter_complex', chains.join(';'),
+    '-map', '[effectsout]',
+    ...pcmOutputArgs(outputPath),
+  );
+  return args;
+}
+
+export async function buildSoundEffects(
+  outputPath: string,
+  options: AudioExecutionOptions & { effects?: readonly SoundEffectCue[] } = {},
+): Promise<string> {
+  await mkdir(dirname(outputPath), { recursive: true });
+  const runner = options.runner ?? runCommand;
+  const ffmpegPath = await resolveFfmpegPath(options);
+  await runner(
+    ffmpegPath,
+    buildSoundEffectsArgs(options.effects ?? DEFAULT_SOUND_EFFECTS, outputPath),
+  );
+  return outputPath;
+}
+
+function buildDuckingExpression(cues: readonly StoryboardCue[]): string {
+  if (cues.length === 0) return '';
+  return cues.map((cue) => {
+    assertFiniteTime(cue.start, `旁白 ${cue.id} 开始时间`);
+    assertFiniteTime(cue.end, `旁白 ${cue.id} 结束时间`);
+    if (cue.end <= cue.start) throw new Error(`旁白 ${cue.id} 时间范围无效`);
+    return `between(t,${formatSeconds(cue.start)},${formatSeconds(cue.end)})`;
+  }).join('+');
+}
+
+export function buildAudioMixArgs(options: BuildAudioMixOptions): string[] {
+  assertPath(options.voiceoverPath, '旁白路径');
+  assertPath(options.musicPath, '背景音乐路径');
+  assertPath(options.effectsPath, '音效路径');
+  assertPath(options.outputPath, '原始混音输出路径');
+  const duckingExpression = buildDuckingExpression(options.voiceoverCues);
+  const musicVolume = duckingExpression
+    ? `volume=${DUCKING_GAIN}:enable='${duckingExpression}'`
+    : 'anull';
+  const filter = [
+    `[0:a]aformat=sample_rates=48000:channel_layouts=stereo[voice]`,
+    `[1:a]aformat=sample_rates=48000:channel_layouts=stereo,${musicVolume}[music]`,
+    `[2:a]aformat=sample_rates=48000:channel_layouts=stereo[effects]`,
+    '[voice][music][effects]amix=inputs=3:normalize=0:duration=longest,'
+      + `alimiter=limit=${TRUE_PEAK_LIMIT},atrim=0:${DEMO_DURATION_SECONDS},`
+      + `apad=whole_dur=${DEMO_DURATION_SECONDS}[mixout]`,
+  ].join(';');
+
+  return [
+    '-hide_banner',
+    '-nostdin',
+    '-y',
+    '-i', options.voiceoverPath,
+    '-i', options.musicPath,
+    '-i', options.effectsPath,
+    '-filter_complex', filter,
+    '-map', '[mixout]',
+    ...pcmOutputArgs(options.outputPath),
+  ];
+}
+
+function unmasteredPath(outputPath: string): string {
+  const extension = basename(outputPath).match(/(\.[^.]+)$/)?.[1] ?? '.wav';
+  const stem = basename(outputPath, extension);
+  return join(dirname(outputPath), `${stem}.unmastered${extension}`);
+}
+
+/**
+ * 执行两遍响度规范化：第一遍只分析，第二遍使用测量值线性渲染。
+ */
+export async function mixDemoAudio(options: MixDemoAudioOptions): Promise<string> {
+  await mkdir(dirname(options.outputPath), { recursive: true });
+  const runner = options.runner ?? runCommand;
+  const ffmpegPath = await resolveFfmpegPath(options);
+  const rawMixPath = unmasteredPath(options.outputPath);
+
+  await runner(ffmpegPath, buildAudioMixArgs({
+    voiceoverPath: options.voiceoverPath,
+    musicPath: options.musicPath,
+    effectsPath: options.effectsPath,
+    outputPath: rawMixPath,
+    voiceoverCues: options.voiceoverCues,
+  }));
+  const analysis = await runner(ffmpegPath, buildLoudnormAnalysisArgs(rawMixPath));
+  const measurement = parseLoudnormMeasurement(`${analysis.stdout}\n${analysis.stderr}`);
+  await runner(
+    ffmpegPath,
+    buildLoudnormRenderArgs(rawMixPath, options.outputPath, measurement),
+  );
+  return options.outputPath;
+}

--- a/scripts/product-demo/browser.test.ts
+++ b/scripts/product-demo/browser.test.ts
@@ -1,0 +1,292 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+import vm from 'node:vm';
+
+import type { ChildProcess } from 'node:child_process';
+import type { Browser, BrowserContext, WebSocketRoute } from 'playwright';
+
+import {
+  DEMO_FIXED_TIME,
+  DEMO_CHROMIUM_ARGS,
+  buildDemoServerCommand,
+  buildDeterministicBrowserInitScript,
+  createDemoContext,
+  createDemoContextOptions,
+  isAllowedDemoRequest,
+  normalizeDemoBaseUrl,
+  stopDemoServer,
+  waitForDemoServer,
+} from './browser.ts';
+
+test('固定演示时间晚于当天最后活动和日报生成时间', () => {
+  assert.equal(DEMO_FIXED_TIME, '2026-08-12T18:00:00+08:00');
+});
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function createFakeChildProcess(
+  onKill: (signal: NodeJS.Signals, process: EventEmitter) => void,
+): ChildProcess {
+  const child = new EventEmitter() as EventEmitter & {
+    exitCode: number | null;
+    signalCode: NodeJS.Signals | null;
+    kill: (signal?: NodeJS.Signals | number) => boolean;
+  };
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = (signal = 'SIGTERM') => {
+    onKill(signal as NodeJS.Signals, child);
+    return true;
+  };
+  return child as unknown as ChildProcess;
+}
+
+test('演示地址只接受 HTTP(S) 并规范为目录 URL', () => {
+  assert.equal(normalizeDemoBaseUrl('http://127.0.0.1:5173').href, 'http://127.0.0.1:5173/');
+  assert.equal(normalizeDemoBaseUrl('https://localhost:5173/demo').href, 'https://localhost:5173/demo/');
+  assert.throws(() => normalizeDemoBaseUrl('file:///tmp/demo'), /HTTP\(S\)/);
+});
+
+test('网络白名单只放行演示同源、data 和 blob 请求', () => {
+  const baseUrl = new URL('http://127.0.0.1:5173/');
+  assert.equal(isAllowedDemoRequest('http://127.0.0.1:5173/src/main.ts', baseUrl), true);
+  assert.equal(isAllowedDemoRequest('data:image/png;base64,AA==', baseUrl), true);
+  assert.equal(isAllowedDemoRequest('blob:http://127.0.0.1:5173/demo', baseUrl), true);
+  assert.equal(isAllowedDemoRequest('https://docs.example.test/demo', baseUrl), false);
+  assert.equal(isAllowedDemoRequest('http://localhost:5173/', baseUrl), false);
+  assert.equal(isAllowedDemoRequest('not-a-url', baseUrl), false);
+});
+
+test('固定浏览器状态脚本不依赖 tsx 辅助函数并冻结演示时间', () => {
+  const script = buildDeterministicBrowserInitScript('2026-08-12T10:30:00+08:00');
+  assert.doesNotMatch(script, /__name/);
+  assert.match(script, /2026-08-12T10:30:00\+08:00/);
+  assert.match(script, /Date/);
+  assert.match(script, /Math\.random/);
+});
+
+test('固定 Date 保留函数、构造器、静态方法和 instanceof 原生语义', () => {
+  const fixedTime = '2026-08-12T10:30:00+08:00';
+  const storage = new Map<string, string>();
+  const browserWindow = {
+    Date,
+    localStorage: {
+      setItem(key: string, value: string) {
+        storage.set(key, value);
+      },
+    },
+  };
+  const document = {
+    head: { appendChild() {} },
+    createElement() {
+      return { dataset: {}, textContent: '' };
+    },
+    addEventListener() {},
+  };
+  const sandbox = {
+    window: browserWindow,
+    document,
+    Math: Object.create(Math) as Math,
+  };
+
+  vm.runInNewContext(buildDeterministicBrowserInitScript(fixedTime), sandbox);
+
+  const DemoDate = browserWindow.Date;
+  const fixedTimestamp = new Date(fixedTime).getTime();
+  const fixedDate = new DemoDate();
+  const explicitDate = new DemoDate('2020-01-02T03:04:05.000Z');
+
+  assert.equal(DemoDate(), new Date(fixedTimestamp).toString());
+  assert.equal(fixedDate.getTime(), fixedTimestamp);
+  assert.equal(explicitDate.toISOString(), '2020-01-02T03:04:05.000Z');
+  assert.equal(DemoDate.now(), fixedTimestamp);
+  assert.equal(DemoDate.parse('2020-01-02T03:04:05.000Z'), Date.parse('2020-01-02T03:04:05.000Z'));
+  assert.equal(DemoDate.UTC(2020, 0, 2, 3, 4, 5), Date.UTC(2020, 0, 2, 3, 4, 5));
+  assert.equal(fixedDate instanceof DemoDate, true);
+  assert.equal(fixedDate instanceof Date, true);
+});
+
+test('浏览器录制参数包含稳定字体和 sRGB 开关', () => {
+  assert.deepEqual(DEMO_CHROMIUM_ARGS, [
+    '--disable-gpu',
+    '--disable-lcd-text',
+    '--disable-skia-runtime-opts',
+    '--font-render-hinting=none',
+    '--force-color-profile=srgb',
+  ]);
+  assert.deepEqual(createDemoContextOptions('9x16').viewport, { width: 1080, height: 1920 });
+});
+
+test('服务轮询在返回成功状态后结束', async () => {
+  let calls = 0;
+  await waitForDemoServer(new URL('http://127.0.0.1:5173/'), {
+    timeoutMs: 100,
+    pollIntervalMs: 0,
+    fetchImpl: async () => {
+      calls += 1;
+      return { ok: calls >= 3 };
+    },
+  });
+  assert.equal(calls, 3);
+});
+
+test('服务轮询超时会提供明确错误', async () => {
+  await assert.rejects(
+    waitForDemoServer(new URL('http://127.0.0.1:5173/'), {
+      timeoutMs: 5,
+      pollIntervalMs: 0,
+      fetchImpl: async () => ({ ok: false }),
+    }),
+    /Vite.*超时/,
+  );
+});
+
+test('服务单次 fetch 永不结束时仍在总超时内失败', async () => {
+  const startedAt = Date.now();
+  const outcome = await Promise.race([
+    waitForDemoServer(new URL('http://127.0.0.1:5173/'), {
+      timeoutMs: 20,
+      pollIntervalMs: 0,
+      fetchImpl: async () => new Promise<{ ok: boolean }>(() => {}),
+    }).then(
+      () => ({ status: 'resolved' as const }),
+      (error: unknown) => ({ status: 'rejected' as const, error }),
+    ),
+    sleep(150).then(() => ({ status: 'hung' as const })),
+  ]);
+
+  assert.equal(outcome.status, 'rejected');
+  assert.match(String('error' in outcome ? outcome.error : ''), /Vite.*超时/);
+  assert.ok(Date.now() - startedAt < 140, '服务轮询必须受总超时约束');
+});
+
+test('停止服务会先注册 exit 等待再发送 SIGKILL', async () => {
+  const signals: NodeJS.Signals[] = [];
+  let listenersAtSigkill = 0;
+  const child = createFakeChildProcess((signal, process) => {
+    signals.push(signal);
+    if (signal === 'SIGKILL') {
+      listenersAtSigkill = process.listenerCount('exit');
+      process.emit('exit', null, 'SIGKILL');
+    }
+  });
+
+  const outcome = await Promise.race([
+    stopDemoServer(
+      { baseUrl: new URL('http://127.0.0.1:5173/'), process: child, logs: [] },
+      { gracefulTimeoutMs: 5, forceTimeoutMs: 20 },
+    ).then(() => 'completed' as const),
+    sleep(150).then(() => 'hung' as const),
+  ]);
+
+  assert.equal(outcome, 'completed');
+  assert.deepEqual(signals, ['SIGTERM', 'SIGKILL']);
+  assert.ok(listenersAtSigkill > 0, 'SIGKILL 前必须先监听 exit');
+});
+
+test('停止服务在 SIGKILL 后仍无 exit 时有限超时并报错', async () => {
+  const child = createFakeChildProcess(() => {});
+  const outcome = await Promise.race([
+    stopDemoServer(
+      { baseUrl: new URL('http://127.0.0.1:5173/'), process: child, logs: [] },
+      { gracefulTimeoutMs: 5, forceTimeoutMs: 10 },
+    ).then(
+      () => ({ status: 'resolved' as const }),
+      (error: unknown) => ({ status: 'rejected' as const, error }),
+    ),
+    sleep(150).then(() => ({ status: 'hung' as const })),
+  ]);
+
+  assert.equal(outcome.status, 'rejected');
+  assert.match(String('error' in outcome ? outcome.error : ''), /SIGKILL.*超时/);
+});
+
+test('浏览器上下文放行同源 WebSocket 并阻断、记录外部 WebSocket', async () => {
+  let websocketHandler: ((route: WebSocketRoute) => Promise<unknown> | unknown) | undefined;
+  const fakeContext = {
+    async route() {},
+    async routeWebSocket(
+      _url: string | RegExp | ((url: URL) => boolean),
+      handler: (route: WebSocketRoute) => Promise<unknown> | unknown,
+    ) {
+      websocketHandler = handler;
+    },
+    async addInitScript() {},
+  };
+  const fakeBrowser = {
+    async newContext() {
+      return fakeContext as unknown as BrowserContext;
+    },
+  };
+  const diagnostics = { blockedWebSockets: [] as string[] };
+  const baseUrl = new URL('http://127.0.0.1:5173/');
+
+  await createDemoContext(
+    fakeBrowser as unknown as Browser,
+    '16x9',
+    undefined,
+    baseUrl,
+    diagnostics,
+  );
+  assert.ok(websocketHandler, '必须注册 WebSocket 路由');
+
+  let sameOriginConnected = false;
+  let sameOriginClosed = false;
+  await websocketHandler({
+    url: () => 'ws://127.0.0.1:5173/?token=demo',
+    connectToServer() {
+      sameOriginConnected = true;
+      return {} as WebSocketRoute;
+    },
+    async close() {
+      sameOriginClosed = true;
+    },
+  } as unknown as WebSocketRoute);
+
+  let externalConnected = false;
+  let externalCloseOptions: { code?: number; reason?: string } | undefined;
+  await websocketHandler({
+    url: () => 'wss://telemetry.example.test/socket',
+    connectToServer() {
+      externalConnected = true;
+      return {} as WebSocketRoute;
+    },
+    async close(options?: { code?: number; reason?: string }) {
+      externalCloseOptions = options;
+    },
+  } as unknown as WebSocketRoute);
+
+  assert.equal(sameOriginConnected, true);
+  assert.equal(sameOriginClosed, false);
+  assert.equal(externalConnected, false);
+  assert.deepEqual(externalCloseOptions, {
+    code: 1008,
+    reason: '产品演示禁止外部 WebSocket',
+  });
+  assert.deepEqual(diagnostics.blockedWebSockets, [
+    'wss://telemetry.example.test/socket',
+  ]);
+});
+
+
+test('演示服务直接启动本地 Vite 入口，避免 npm 孙进程残留', () => {
+  const command = buildDemoServerCommand(
+    '/workspace/work-review',
+    new URL('http://127.0.0.1:5173/'),
+  );
+
+  assert.equal(command.binary, process.execPath);
+  assert.deepEqual(command.args, [
+    '/workspace/work-review/node_modules/vite/bin/vite.js',
+    '--host',
+    '127.0.0.1',
+    '--port',
+    '5173',
+    '--strictPort',
+  ]);
+  assert.equal(command.cwd, '/workspace/work-review');
+  assert.doesNotMatch(command.args.join(' '), /npm run dev/u);
+});

--- a/scripts/product-demo/browser.ts
+++ b/scripts/product-demo/browser.ts
@@ -1,0 +1,401 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { access } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+import {
+  chromium,
+  type Browser,
+  type BrowserContext,
+  type BrowserContextOptions,
+} from 'playwright';
+
+import type { DemoAspect } from './types.ts';
+
+export const DEMO_FIXED_TIME = '2026-08-12T18:00:00+08:00';
+export const DEMO_BASE_URL = new URL('http://127.0.0.1:5173/');
+
+export const DEMO_CHROMIUM_ARGS = [
+  '--disable-gpu',
+  '--disable-lcd-text',
+  '--disable-skia-runtime-opts',
+  '--font-render-hinting=none',
+  '--force-color-profile=srgb',
+] as const;
+
+const MACOS_BROWSER_FALLBACKS = [
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+] as const;
+
+export interface DemoRecordingConfig {
+  viewport: { width: number; height: number };
+  videoSize: { width: number; height: number };
+  deviceScaleFactor: number;
+  locale: 'zh-CN';
+  timezoneId: 'Asia/Shanghai';
+  reducedMotion: 'reduce';
+}
+
+export interface DemoServer {
+  baseUrl: URL;
+  process: ChildProcess;
+  logs: string[];
+}
+
+export interface WaitForDemoServerOptions {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  fetchImpl?: (
+    url: string,
+    options?: { signal?: AbortSignal },
+  ) => Promise<{ ok: boolean }>;
+}
+
+export interface StopDemoServerOptions {
+  gracefulTimeoutMs?: number;
+  forceTimeoutMs?: number;
+}
+
+export interface DemoNetworkDiagnostics {
+  blockedWebSockets: string[];
+}
+
+export const DEMO_RECORDING_CONFIG: Record<DemoAspect, DemoRecordingConfig> = {
+  '16x9': {
+    viewport: { width: 1920, height: 1080 },
+    videoSize: { width: 1920, height: 1080 },
+    deviceScaleFactor: 1,
+    locale: 'zh-CN',
+    timezoneId: 'Asia/Shanghai',
+    reducedMotion: 'reduce',
+  },
+  '9x16': {
+    viewport: { width: 1080, height: 1920 },
+    videoSize: { width: 1080, height: 1920 },
+    deviceScaleFactor: 1,
+    locale: 'zh-CN',
+    timezoneId: 'Asia/Shanghai',
+    reducedMotion: 'reduce',
+  },
+};
+
+export function normalizeDemoBaseUrl(value: string): URL {
+  const url = new URL(value);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('产品演示地址必须是 HTTP(S) URL。');
+  }
+  if (!url.pathname.endsWith('/')) url.pathname += '/';
+  return url;
+}
+
+export function isAllowedDemoRequest(value: string, baseUrl = DEMO_BASE_URL): boolean {
+  try {
+    const requestUrl = new URL(value);
+    return requestUrl.origin === baseUrl.origin
+      || requestUrl.protocol === 'data:'
+      || requestUrl.protocol === 'blob:';
+  } catch {
+    return false;
+  }
+}
+
+export function isAllowedDemoWebSocket(
+  value: string,
+  baseUrl = DEMO_BASE_URL,
+): boolean {
+  try {
+    const websocketUrl = new URL(value);
+    if (websocketUrl.protocol !== 'ws:' && websocketUrl.protocol !== 'wss:') {
+      return false;
+    }
+    websocketUrl.protocol = websocketUrl.protocol === 'ws:' ? 'http:' : 'https:';
+    return websocketUrl.origin === baseUrl.origin;
+  } catch {
+    return false;
+  }
+}
+
+export function createDemoContextOptions(
+  aspect: DemoAspect,
+  videoDir?: string,
+): BrowserContextOptions {
+  const config = DEMO_RECORDING_CONFIG[aspect];
+  return {
+    viewport: { ...config.viewport },
+    deviceScaleFactor: config.deviceScaleFactor,
+    locale: config.locale,
+    timezoneId: config.timezoneId,
+    reducedMotion: config.reducedMotion,
+    colorScheme: 'light',
+    ...(videoDir
+      ? {
+          recordVideo: {
+            dir: videoDir,
+            size: { ...config.videoSize },
+          },
+        }
+      : {}),
+  };
+}
+
+export function buildDeterministicBrowserInitScript(fixedTime = DEMO_FIXED_TIME): string {
+  const serializedTime = JSON.stringify(fixedTime);
+  return `(() => {
+    const NativeDate = window.Date;
+    const fixedTimestamp = new NativeDate(${serializedTime}).getTime();
+    function DemoDate(...args) {
+      if (!new.target) return new NativeDate(fixedTimestamp).toString();
+      return Reflect.construct(
+        NativeDate,
+        args.length === 0 ? [fixedTimestamp] : args,
+        new.target,
+      );
+    }
+    Object.setPrototypeOf(DemoDate, NativeDate);
+    DemoDate.prototype = NativeDate.prototype;
+    Object.defineProperty(DemoDate, 'now', {
+      configurable: true,
+      value: () => fixedTimestamp,
+    });
+    window.Date = DemoDate;
+    Math.random = () => 0.424242;
+    window.localStorage.setItem('work-review.locale', 'zh-CN');
+    window.localStorage.setItem('theme', 'light');
+    const style = document.createElement('style');
+    style.dataset.workReviewDemo = 'deterministic';
+    style.textContent = '*,:before,:after{scroll-behavior:auto!important;}';
+    const attachStyle = () => document.head?.appendChild(style);
+    if (document.head) attachStyle();
+    else document.addEventListener('DOMContentLoaded', attachStyle, { once: true });
+  })();`;
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function fetchBeforeDeadline(
+  url: string,
+  remainingMs: number,
+  fetchImpl: NonNullable<WaitForDemoServerOptions['fetchImpl']>,
+): Promise<{ ok: boolean }> {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      fetchImpl(url, { signal: controller.signal }),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          controller.abort();
+          reject(new Error('产品演示服务单次请求超时。'));
+        }, Math.max(0, remainingMs));
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+export async function waitForDemoServer(
+  baseUrl: URL,
+  options: WaitForDemoServerOptions = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const pollIntervalMs = options.pollIntervalMs ?? 150;
+  const fetchImpl = options.fetchImpl ?? (
+    (url: string, requestOptions?: { signal?: AbortSignal }) => fetch(url, requestOptions)
+  );
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() <= deadline) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs < 0) break;
+    try {
+      const response = await fetchBeforeDeadline(baseUrl.href, remainingMs, fetchImpl);
+      if (response.ok) return;
+    } catch {
+      // Vite 启动期间连接失败或单次请求超时属于预期，由总截止时间统一判定。
+    }
+    const delayMs = Math.min(pollIntervalMs, Math.max(0, deadline - Date.now()));
+    if (delayMs > 0) await delay(delayMs);
+  }
+
+  throw new Error(`等待产品演示 Vite 服务超时（${timeoutMs}ms）：${baseUrl.href}`);
+}
+
+export interface DemoServerCommand {
+  binary: string;
+  args: string[];
+  cwd: string;
+}
+
+/** 直接启动本地 Vite CLI，避免 npm 包装进程遗留孙进程。 */
+export function buildDemoServerCommand(cwd: string, baseUrl: URL): DemoServerCommand {
+  const port = baseUrl.port || (baseUrl.protocol === 'https:' ? '443' : '80');
+  return {
+    binary: process.execPath,
+    args: [
+      path.join(cwd, 'node_modules', 'vite', 'bin', 'vite.js'),
+      '--host',
+      baseUrl.hostname,
+      '--port',
+      port,
+      '--strictPort',
+    ],
+    cwd,
+  };
+}
+
+export async function startDemoServer(options: {
+  cwd?: string;
+  baseUrl?: URL;
+  timeoutMs?: number;
+} = {}): Promise<DemoServer> {
+  const baseUrl = options.baseUrl ?? DEMO_BASE_URL;
+  const command = buildDemoServerCommand(options.cwd ?? process.cwd(), baseUrl);
+  const child = spawn(
+    command.binary,
+    command.args,
+    {
+      cwd: command.cwd,
+      env: { ...process.env, NO_COLOR: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  const logs: string[] = [];
+  child.stdout.on('data', (chunk: Buffer) => logs.push(chunk.toString()));
+  child.stderr.on('data', (chunk: Buffer) => logs.push(chunk.toString()));
+
+  try {
+    await Promise.race([
+      waitForDemoServer(baseUrl, { timeoutMs: options.timeoutMs }),
+      new Promise<never>((_, reject) => {
+        child.once('exit', (code, signal) => {
+          reject(new Error(
+            `产品演示 Vite 服务提前退出（code=${String(code)}, signal=${String(signal)}）：\n${logs.join('')}`,
+          ));
+        });
+        child.once('error', reject);
+      }),
+    ]);
+  } catch (error) {
+    await stopDemoServer({ baseUrl, process: child, logs });
+    throw error;
+  }
+
+  return { baseUrl, process: child, logs };
+}
+
+function hasProcessExited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+function waitForProcessExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (hasProcessExited(child)) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (exited: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      child.off('exit', onExit);
+      resolve(exited);
+    };
+    const onExit = () => finish(true);
+    child.once('exit', onExit);
+    const timeout = setTimeout(() => finish(false), Math.max(0, timeoutMs));
+    if (hasProcessExited(child)) finish(true);
+  });
+}
+
+export async function stopDemoServer(
+  server: DemoServer,
+  options: StopDemoServerOptions = {},
+): Promise<void> {
+  const gracefulTimeoutMs = options.gracefulTimeoutMs ?? 2_000;
+  const forceTimeoutMs = options.forceTimeoutMs ?? 2_000;
+  if (hasProcessExited(server.process)) return;
+
+  const gracefulExit = waitForProcessExit(server.process, gracefulTimeoutMs);
+  server.process.kill('SIGTERM');
+  if (await gracefulExit || hasProcessExited(server.process)) return;
+
+  const forcedExit = waitForProcessExit(server.process, forceTimeoutMs);
+  server.process.kill('SIGKILL');
+  if (await forcedExit || hasProcessExited(server.process)) return;
+
+  throw new Error(`产品演示 Vite 服务 SIGKILL 后退出超时（${forceTimeoutMs}ms）。`);
+}
+
+async function firstAccessible(paths: readonly string[]): Promise<string | undefined> {
+  for (const candidate of paths) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // 继续尝试下一个候选浏览器。
+    }
+  }
+  return undefined;
+}
+
+export async function resolveDemoBrowserExecutable(): Promise<string | undefined> {
+  const bundled = chromium.executablePath();
+  const candidates = process.platform === 'darwin'
+    ? [bundled, ...MACOS_BROWSER_FALLBACKS]
+    : [bundled];
+  return firstAccessible(candidates);
+}
+
+export async function launchDemoBrowser(): Promise<Browser> {
+  const executablePath = await resolveDemoBrowserExecutable();
+  if (!executablePath) {
+    throw new Error(
+      '未找到可用浏览器。请执行 `npx playwright install chromium`，或在 macOS 安装 Google Chrome / Microsoft Edge。',
+    );
+  }
+  return chromium.launch({
+    headless: true,
+    executablePath,
+    args: [...DEMO_CHROMIUM_ARGS],
+  });
+}
+
+export async function installDeterministicBrowserState(
+  context: BrowserContext,
+  fixedTime = DEMO_FIXED_TIME,
+): Promise<void> {
+  await context.addInitScript({ content: buildDeterministicBrowserInitScript(fixedTime) });
+}
+
+export async function createDemoContext(
+  browser: Browser,
+  aspect: DemoAspect,
+  videoDir?: string,
+  baseUrl = DEMO_BASE_URL,
+  diagnostics?: DemoNetworkDiagnostics,
+): Promise<BrowserContext> {
+  const context = await browser.newContext(createDemoContextOptions(aspect, videoDir));
+  await context.route('**/*', async (route) => {
+    if (isAllowedDemoRequest(route.request().url(), baseUrl)) {
+      await route.continue();
+      return;
+    }
+    await route.abort('blockedbyclient');
+  });
+  await context.routeWebSocket('**/*', async (websocket) => {
+    const url = websocket.url();
+    if (isAllowedDemoWebSocket(url, baseUrl)) {
+      websocket.connectToServer();
+      return;
+    }
+    diagnostics?.blockedWebSockets.push(url);
+    await websocket.close({
+      code: 1008,
+      reason: '产品演示禁止外部 WebSocket',
+    });
+  });
+  await installDeterministicBrowserState(context);
+  return context;
+}

--- a/scripts/product-demo/capture.test.ts
+++ b/scripts/product-demo/capture.test.ts
@@ -1,0 +1,321 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import type { Browser, BrowserContext, Page, Video } from 'playwright';
+
+import type { DemoNetworkDiagnostics } from './browser.ts';
+
+import {
+  assertCleanCaptureDiagnostics,
+  buildDemoRouteUrl,
+  buildSceneCapturePaths,
+  cleanupCaptureResources,
+  createCaptureDiagnostics,
+  recordScene,
+} from './capture.ts';
+import { createDemoFixtures } from './fixtures.ts';
+import { STORYBOARD } from './storyboard.ts';
+import { createDemoMockState } from './tauriMock.ts';
+import type { DemoMockState, ShotRunner } from './types.ts';
+
+test('分镜路由使用同源 Hash 路由并保留查询参数', () => {
+  assert.equal(
+    buildDemoRouteUrl(new URL('http://127.0.0.1:5173/'), '/timeline?date=2026-08-12'),
+    'http://127.0.0.1:5173/#/timeline?date=2026-08-12',
+  );
+});
+
+test('录制路径按横竖屏和分镜隔离并包含三张关键帧与元数据', () => {
+  assert.deepEqual(
+    buildSceneCapturePaths('/tmp/work-review-demo/intermediate', '9x16', 'assistant'),
+    {
+      aspectDir: '/tmp/work-review-demo/intermediate/9x16',
+      videoPath: '/tmp/work-review-demo/intermediate/9x16/assistant.webm',
+      startFramePath: '/tmp/work-review-demo/intermediate/9x16/assistant-start.png',
+      actionFramePath: '/tmp/work-review-demo/intermediate/9x16/assistant-action.png',
+      endFramePath: '/tmp/work-review-demo/intermediate/9x16/assistant-end.png',
+      metadataPath: '/tmp/work-review-demo/intermediate/9x16/assistant.json',
+    },
+  );
+});
+
+test('页面错误、控制台 error、外部请求和未处理命令都会阻止交付', () => {
+  const diagnostics = createCaptureDiagnostics();
+  diagnostics.pageErrors.push('渲染失败');
+  diagnostics.consoleErrors.push('状态错误');
+  diagnostics.blockedRequests.push('https://example.com/pixel');
+  diagnostics.unhandledCommands.push('missing_command');
+
+  assert.throws(
+    () => assertCleanCaptureDiagnostics(diagnostics, 'timeline'),
+    /timeline[\s\S]*渲染失败[\s\S]*example\.com[\s\S]*missing_command/,
+  );
+});
+
+test('无错误诊断可以继续录制', () => {
+  assert.doesNotThrow(() => assertCleanCaptureDiagnostics(createCaptureDiagnostics(), 'hook'));
+  assert.equal(STORYBOARD.length, 7);
+});
+
+interface RecordHarnessOptions {
+  sceneId?: 'hook' | 'export';
+  exportedFilesSnapshot?: unknown;
+  onExportRead?: () => void;
+  outputDir?: string;
+  rawContent?: string;
+  existingVideoContent?: string;
+  now?: () => number;
+  onContextFactory?: (diagnostics?: DemoNetworkDiagnostics) => void;
+  onGoto?: () => void;
+  onScreenshot?: (outputPath: string) => void;
+  runner?: ShotRunner;
+  close?: () => Promise<void>;
+  state?: DemoMockState & { unhandledCommands?: string[] };
+  probeMediaFile?: (mediaPath: string) => Promise<{ durationSeconds: number | null }>;
+  replaceFile?: (sourcePath: string, outputPath: string) => Promise<void>;
+}
+
+async function runSceneCapture(options: RecordHarnessOptions = {}) {
+  const rootDir = options.outputDir
+    ? path.dirname(options.outputDir)
+    : await mkdtemp(path.join(tmpdir(), 'work-review-capture-test-'));
+  const outputDir = options.outputDir ?? path.join(rootDir, 'intermediate');
+  const rawVideoPath = path.join(rootDir, 'raw.webm');
+  await writeFile(rawVideoPath, options.rawContent ?? 'raw-video', 'utf8');
+
+  const fixtures = createDemoFixtures();
+  const scene = STORYBOARD.find((entry) => entry.id === (options.sceneId ?? 'hook'))!;
+  if (options.existingVideoContent !== undefined) {
+    const existingPaths = buildSceneCapturePaths(outputDir, '16x9', scene.id);
+    await mkdir(existingPaths.aspectDir, { recursive: true });
+    await writeFile(existingPaths.videoPath, options.existingVideoContent, 'utf8');
+  }
+  const state = options.state ?? createDemoMockState(fixtures);
+  const waits: number[] = [];
+  const screenshotPaths: string[] = [];
+  const video = {
+    path: async () => rawVideoPath,
+  } as Video;
+  const page = {
+    on: () => undefined,
+    video: () => video,
+    goto: async () => {
+      options.onGoto?.();
+    },
+    waitForFunction: async () => undefined,
+    screenshot: async ({ path: outputPath }: { path: string }) => {
+      await writeFile(outputPath, 'frame', 'utf8');
+      screenshotPaths.push(outputPath);
+      options.onScreenshot?.(outputPath);
+    },
+    waitForTimeout: async (milliseconds: number) => {
+      waits.push(milliseconds);
+    },
+    evaluate: async () => {
+      options.onExportRead?.();
+      return options.exportedFilesSnapshot ?? [];
+    },
+  } as unknown as Page;
+  const context = {
+    newPage: async () => page,
+    close: options.close ?? (async () => undefined),
+  } as unknown as BrowserContext;
+  const runner = options.runner ?? (async () => undefined);
+
+  const result = await recordScene(scene, '16x9', outputDir, {
+    browser: {} as Browser,
+    fixtures,
+    contextFactory: async (_browser, _aspect, _videoDir, _baseUrl, diagnostics) => {
+      options.onContextFactory?.(diagnostics);
+      return context;
+    },
+    mockInstaller: async () => state,
+    shotRunners: { [scene.id]: runner } as never,
+    now: options.now,
+    probeMediaFile: options.probeMediaFile ?? (async () => ({ durationSeconds: 7.5 })),
+    replaceFile: options.replaceFile,
+  });
+
+  return {
+    outputDir,
+    rawVideoPath,
+    result,
+    screenshotPaths,
+    waits,
+  };
+}
+
+async function runHookCapture(options: RecordHarnessOptions = {}) {
+  return runSceneCapture({ ...options, sceneId: 'hook' });
+}
+
+test('export 镜头只读取页面暴露接口产生的实际 Markdown，且 metadata 不包含内容或路径', async () => {
+  const fixtures = createDemoFixtures();
+  let exportReads = 0;
+  const content = '# 2026-08-12 日报\n\nUI 实际导出内容';
+  const capture = await runSceneCapture({
+    sceneId: 'export',
+    exportedFilesSnapshot: [{
+      path: fixtures.exportPath,
+      content,
+      kind: 'markdown',
+    }],
+    onExportRead: () => { exportReads += 1; },
+  });
+
+  assert.equal(exportReads, 1);
+  assert.deepEqual(capture.result.exportedMarkdown, {
+    fileName: '2026-08-12.md',
+    content,
+  });
+  const metadata = await readFile(capture.result.paths.metadataPath, 'utf8');
+  assert.doesNotMatch(metadata, /UI 实际导出内容|exportedMarkdown|work-review-demo/u);
+});
+
+test('export 镜头缺少 UI 实际导出的目标 Markdown 时立即失败', async () => {
+  await assert.rejects(
+    runSceneCapture({ sceneId: 'export', exportedFilesSnapshot: [] }),
+    /export.*2026-08-12\.md.*实际导出/u,
+  );
+});
+
+test('浏览器上下文阻断的外部 WebSocket 会进入录制诊断', async () => {
+  await assert.rejects(
+    runHookCapture({
+      onContextFactory: (diagnostics) => {
+        diagnostics?.blockedWebSockets.push('wss://example.com/socket');
+      },
+    }),
+    /example\.com\/socket/,
+  );
+});
+
+test('目标录制时长从页面准备且起始帧完成后开始计算', async () => {
+  let currentTime = 0;
+  const capture = await runHookCapture({
+    now: () => currentTime,
+    onContextFactory: () => {
+      currentTime = 2_000;
+    },
+    onGoto: () => {
+      currentTime = 4_000;
+    },
+    runner: async ({ markContentStart, captureActionFrame }) => {
+      currentTime = 5_250;
+      markContentStart?.();
+      currentTime = 5_500;
+      await captureActionFrame?.();
+    },
+    onScreenshot: (outputPath) => {
+      if (outputPath.endsWith('-start.png')) currentTime = 5_000;
+    },
+  });
+
+  assert.deepEqual(capture.waits, [7_000]);
+  assert.equal(capture.result.contentStartOffsetSeconds, 3.25);
+});
+
+test('动作关键帧由分镜在关键瞬态主动捕获且 metadata 不写入宿主机绝对路径', async () => {
+  const capture = await runHookCapture({
+    runner: async ({ captureActionFrame }) => {
+      await captureActionFrame?.();
+    },
+  });
+
+  assert.equal(
+    capture.screenshotPaths.filter((value) => value.endsWith('-action.png')).length,
+    1,
+  );
+  const metadata = await readFile(capture.result.paths.metadataPath, 'utf8');
+  assert.doesNotMatch(metadata, /\/Users\/|[A-Z]:\\/u);
+  assert.doesNotMatch(metadata, /"paths"/u);
+  assert.match(metadata, /"contentStartOffsetSeconds"/u);
+});
+
+test('metadata 使用可注入媒体探测器返回的实际 WebM 时长', async () => {
+  const probedPaths: string[] = [];
+  const capture = await runHookCapture({
+    probeMediaFile: async (mediaPath) => {
+      probedPaths.push(mediaPath);
+      return { durationSeconds: 7.234 };
+    },
+  });
+
+  assert.deepEqual(probedPaths, [capture.result.paths.videoPath]);
+  assert.equal(capture.result.durationSeconds, 7.234);
+  const metadata = JSON.parse(
+    await readFile(capture.result.paths.metadataPath, 'utf8'),
+  ) as { durationSeconds: number };
+  assert.equal(metadata.durationSeconds, 7.234);
+});
+
+test('runner 与 context.close 同时失败时首要保留 runner 原始错误', async () => {
+  await assert.rejects(
+    runHookCapture({
+      runner: async () => {
+        throw new Error('runner failed');
+      },
+      close: async () => {
+        throw new Error('context close failed');
+      },
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /runner failed/);
+      if (error instanceof AggregateError) {
+        assert.match(String(error.errors[0]), /runner failed/);
+        assert.match(String(error.errors[1]), /context close failed/);
+      }
+      return true;
+    },
+  );
+});
+
+test('目标视频已存在时通过显式替换策略覆盖旧文件', async () => {
+  let sawExistingDestination = false;
+  const capture = await runHookCapture({
+    rawContent: 'new-video',
+    existingVideoContent: 'old-video',
+    replaceFile: async (sourcePath, outputPath) => {
+      sawExistingDestination = (await readFile(outputPath, 'utf8')) === 'old-video';
+      await writeFile(outputPath, await readFile(sourcePath));
+    },
+  });
+
+  assert.equal(sawExistingDestination, true);
+  assert.equal(await readFile(capture.result.paths.videoPath, 'utf8'), 'new-video');
+});
+
+test('结构化 Mock state 中的未实现命令会阻止录制', async () => {
+  const fixtures = createDemoFixtures();
+  const state = Object.assign(createDemoMockState(fixtures), {
+    unhandledCommands: ['quiet_missing_command'],
+  });
+
+  await assert.rejects(
+    runHookCapture({ state }),
+    /quiet_missing_command/,
+  );
+});
+
+
+test('浏览器关闭失败时仍会继续停止 Vite 服务', async () => {
+  const order: string[] = [];
+  const closeError = new Error('browser close failed');
+
+  await assert.rejects(
+    cleanupCaptureResources(
+      { close: async () => { order.push('browser'); throw closeError; } } as unknown as Browser,
+      { baseUrl: new URL('http://127.0.0.1:5173/'), process: {} as never, logs: [] },
+      async () => { order.push('server'); },
+    ),
+    (error: unknown) => {
+      assert.equal(error, closeError);
+      assert.deepEqual(order, ['browser', 'server']);
+      return true;
+    },
+  );
+});

--- a/scripts/product-demo/capture.ts
+++ b/scripts/product-demo/capture.ts
@@ -1,0 +1,436 @@
+import { mkdir, rename, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { Browser, BrowserContext, Page, Video } from 'playwright';
+
+import {
+  DEMO_BASE_URL,
+  createDemoContext,
+  isAllowedDemoRequest,
+  launchDemoBrowser,
+  startDemoServer,
+  stopDemoServer,
+  type DemoServer,
+} from './browser.ts';
+import { probeMedia } from './ffmpeg.ts';
+import { createDemoFixtures } from './fixtures.ts';
+import { STORYBOARD } from './storyboard.ts';
+import { SHOT_RUNNERS } from './shots.ts';
+import { installDemoTauriMock } from './tauriMock.ts';
+import type {
+  DemoAspect,
+  DemoFixtures,
+  DemoMockState,
+  StoryboardScene,
+  StoryboardSceneId,
+} from './types.ts';
+
+export interface CaptureDiagnostics {
+  pageErrors: string[];
+  consoleErrors: string[];
+  blockedRequests: string[];
+  unhandledCommands: string[];
+}
+
+export interface SceneCapturePaths {
+  aspectDir: string;
+  videoPath: string;
+  startFramePath: string;
+  actionFramePath: string;
+  endFramePath: string;
+  metadataPath: string;
+}
+
+export interface ExportedMarkdownCapture {
+  fileName: string;
+  content: string;
+}
+
+export interface SceneCaptureResult {
+  scene: StoryboardSceneId;
+  aspect: DemoAspect;
+  paths: SceneCapturePaths;
+  contentStartOffsetSeconds: number;
+  durationSeconds: number;
+  diagnostics: CaptureDiagnostics;
+  invokeCommands: string[];
+  /** 仅在进程内传递，不得写入分镜 metadata。 */
+  exportedMarkdown?: ExportedMarkdownCapture;
+}
+
+interface RecordSceneDependencies {
+  browser: Browser;
+  baseUrl?: URL;
+  fixtures?: DemoFixtures;
+  contextFactory?: typeof createDemoContext;
+  mockInstaller?: typeof installDemoTauriMock;
+  shotRunners?: typeof SHOT_RUNNERS;
+  now?: () => number;
+  probeMediaFile?: (mediaPath: string) => Promise<{ durationSeconds: number | null }>;
+  replaceFile?: (sourcePath: string, outputPath: string) => Promise<void>;
+}
+
+export interface CaptureAllScenesOptions {
+  outputDir: string;
+  aspects?: readonly DemoAspect[];
+  sceneIds?: readonly StoryboardSceneId[];
+  cwd?: string;
+  baseUrl?: URL;
+}
+
+export function buildDemoRouteUrl(baseUrl: URL, route: string): string {
+  const normalizedRoute = route.startsWith('/') ? route : `/${route}`;
+  const url = new URL(baseUrl.href);
+  url.hash = `#${normalizedRoute}`;
+  return url.href;
+}
+
+export function buildSceneCapturePaths(
+  outputDir: string,
+  aspect: DemoAspect,
+  sceneId: StoryboardSceneId,
+): SceneCapturePaths {
+  const aspectDir = path.join(outputDir, aspect);
+  return {
+    aspectDir,
+    videoPath: path.join(aspectDir, `${sceneId}.webm`),
+    startFramePath: path.join(aspectDir, `${sceneId}-start.png`),
+    actionFramePath: path.join(aspectDir, `${sceneId}-action.png`),
+    endFramePath: path.join(aspectDir, `${sceneId}-end.png`),
+    metadataPath: path.join(aspectDir, `${sceneId}.json`),
+  };
+}
+
+export function createCaptureDiagnostics(): CaptureDiagnostics {
+  return {
+    pageErrors: [],
+    consoleErrors: [],
+    blockedRequests: [],
+    unhandledCommands: [],
+  };
+}
+
+export function assertCleanCaptureDiagnostics(
+  diagnostics: CaptureDiagnostics,
+  sceneId: StoryboardSceneId,
+): void {
+  const details = [
+    ...diagnostics.pageErrors.map((value) => `页面错误：${value}`),
+    ...diagnostics.consoleErrors.map((value) => `控制台错误：${value}`),
+    ...diagnostics.blockedRequests.map((value) => `外部请求：${value}`),
+    ...diagnostics.unhandledCommands.map((value) => `未处理命令：${value}`),
+  ];
+  if (details.length > 0) {
+    throw new Error(`分镜 ${sceneId} 录制诊断失败：\n${details.join('\n')}`);
+  }
+}
+
+function attachPageDiagnostics(
+  page: Page,
+  diagnostics: CaptureDiagnostics,
+  baseUrl: URL,
+): void {
+  page.on('pageerror', (error) => diagnostics.pageErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return;
+    const text = message.text();
+    diagnostics.consoleErrors.push(text);
+    const match = /产品演示 Tauri Mock 未实现命令：([^\s]+)/u.exec(text);
+    if (match?.[1]) diagnostics.unhandledCommands.push(match[1]);
+  });
+  page.on('request', (request) => {
+    const url = request.url();
+    if (!isAllowedDemoRequest(url, baseUrl)) diagnostics.blockedRequests.push(url);
+  });
+}
+
+async function captureFrame(page: Page, outputPath: string): Promise<void> {
+  await page.screenshot({
+    path: outputPath,
+    fullPage: false,
+    animations: 'disabled',
+    caret: 'hide',
+  });
+}
+
+async function replaceExistingFile(sourcePath: string, outputPath: string): Promise<void> {
+  // Windows 不允许 rename 直接覆盖已存在目标；先显式移除，保证重复录制语义一致。
+  await rm(outputPath, { force: true });
+  await rename(sourcePath, outputPath);
+}
+
+async function persistVideo(
+  video: Video | null,
+  outputPath: string,
+  replaceFile: (sourcePath: string, destinationPath: string) => Promise<void>,
+): Promise<void> {
+  if (!video) throw new Error(`分镜没有产生 Playwright 录屏：${outputPath}`);
+  const temporaryPath = await video.path();
+  await replaceFile(temporaryPath, outputPath);
+}
+
+function collectStructuredMockDiagnostics(
+  state: DemoMockState | undefined,
+  diagnostics: CaptureDiagnostics,
+): void {
+  if (!state) return;
+
+  for (const command of state.unhandledCommands) {
+    if (typeof command !== 'string' || diagnostics.unhandledCommands.includes(command)) continue;
+    diagnostics.unhandledCommands.push(command);
+  }
+}
+
+function requiredMediaDuration(
+  durationSeconds: number | null,
+  mediaPath: string,
+): number {
+  if (durationSeconds === null || !Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+    throw new Error(`无法读取分镜 WebM 实际时长：${mediaPath}`);
+  }
+  return durationSeconds;
+}
+
+function combineCaptureAndCloseErrors(
+  sceneId: StoryboardSceneId,
+  captureError: unknown,
+  closeError: unknown,
+): AggregateError {
+  const captureMessage = captureError instanceof Error ? captureError.message : String(captureError);
+  const closeMessage = closeError instanceof Error ? closeError.message : String(closeError);
+  return new AggregateError(
+    [captureError, closeError],
+    `分镜 ${sceneId} 录制失败：${captureMessage}；关闭浏览器上下文也失败：${closeMessage}`,
+  );
+}
+
+function findScene(sceneId: StoryboardSceneId): StoryboardScene {
+  const scene = STORYBOARD.find((item) => item.id === sceneId);
+  if (!scene) throw new Error(`未知产品演示分镜：${sceneId}`);
+  return scene;
+}
+
+interface BrowserExportedFile {
+  path: string;
+  content: string;
+  kind: 'markdown';
+}
+
+function requireExportedMarkdown(
+  value: unknown,
+  expectedPath: string,
+): ExportedMarkdownCapture {
+  if (!Array.isArray(value)) {
+    throw new Error('export 镜头无法读取 UI 实际导出文件列表');
+  }
+  const matching = value.filter((entry): entry is BrowserExportedFile => (
+    Boolean(entry)
+    && typeof entry === 'object'
+    && (entry as Record<string, unknown>).path === expectedPath
+    && (entry as Record<string, unknown>).kind === 'markdown'
+  ));
+  if (matching.length !== 1) {
+    throw new Error(`export 镜头缺少唯一的 ${path.basename(expectedPath)} UI 实际导出`);
+  }
+  const content = matching[0]!.content;
+  if (typeof content !== 'string' || !content.trim()) {
+    throw new Error(`export 镜头的 UI 实际导出 ${path.basename(expectedPath)} 内容为空`);
+  }
+  return { fileName: path.basename(expectedPath), content };
+}
+
+async function readExportedMarkdown(
+  page: Page,
+  expectedPath: string,
+): Promise<ExportedMarkdownCapture> {
+  const exportedFiles = await page.evaluate(async () => {
+    const readFiles = (window as typeof window & {
+      __WORK_REVIEW_DEMO_EXPORTED_FILES__?: () => Promise<unknown>;
+    }).__WORK_REVIEW_DEMO_EXPORTED_FILES__;
+    if (typeof readFiles !== 'function') {
+      throw new Error('页面未暴露 UI 实际导出读取接口');
+    }
+    return readFiles();
+  });
+  return requireExportedMarkdown(exportedFiles, expectedPath);
+}
+
+export async function recordScene(
+  scene: StoryboardScene,
+  aspect: DemoAspect,
+  outputDir: string,
+  dependencies: RecordSceneDependencies,
+): Promise<SceneCaptureResult> {
+  const baseUrl = dependencies.baseUrl ?? DEMO_BASE_URL;
+  const fixtures = dependencies.fixtures ?? createDemoFixtures();
+  const contextFactory = dependencies.contextFactory ?? createDemoContext;
+  const mockInstaller = dependencies.mockInstaller ?? installDemoTauriMock;
+  const shotRunners = dependencies.shotRunners ?? SHOT_RUNNERS;
+  const now = dependencies.now ?? Date.now;
+  const probeMediaFile = dependencies.probeMediaFile ?? ((mediaPath: string) => probeMedia(mediaPath));
+  const replaceFile = dependencies.replaceFile ?? replaceExistingFile;
+  const paths = buildSceneCapturePaths(outputDir, aspect, scene.id);
+  const diagnostics = createCaptureDiagnostics();
+  let context: BrowserContext | undefined;
+  let video: Video | null = null;
+  let state: DemoMockState | undefined;
+  let captureError: unknown;
+  let recordingOriginAt = 0;
+  let contentStartAt: number | undefined;
+  let actionFrameCaptured = false;
+  let exportedMarkdown: ExportedMarkdownCapture | undefined;
+
+  await mkdir(paths.aspectDir, { recursive: true });
+
+  try {
+    context = await contextFactory(
+      dependencies.browser,
+      aspect,
+      paths.aspectDir,
+      baseUrl,
+      { blockedWebSockets: diagnostics.blockedRequests },
+    );
+    state = await mockInstaller(context, fixtures);
+    const page = await context.newPage();
+    video = page.video();
+    recordingOriginAt = now();
+    attachPageDiagnostics(page, diagnostics, baseUrl);
+
+    await page.goto(buildDemoRouteUrl(baseUrl, scene.route), {
+      waitUntil: 'networkidle',
+      timeout: 30_000,
+    });
+    await page.waitForFunction(() => document.fonts?.status === 'loaded', undefined, {
+      timeout: 10_000,
+    });
+    await captureFrame(page, paths.startFramePath);
+    const recordingStartedAt = now();
+
+    const runner = shotRunners[scene.id];
+    await runner({
+      page,
+      aspect,
+      scene,
+      fixtures,
+      markContentStart: () => {
+        if (contentStartAt !== undefined) {
+          throw new Error(`分镜 ${scene.id} 重复标记正式内容起点`);
+        }
+        contentStartAt = now();
+      },
+      captureActionFrame: async () => {
+        if (actionFrameCaptured) {
+          throw new Error(`分镜 ${scene.id} 重复捕获动作关键帧`);
+        }
+        await captureFrame(page, paths.actionFramePath);
+        actionFrameCaptured = true;
+      },
+    });
+    if (contentStartAt === undefined) contentStartAt = recordingStartedAt;
+    if (!actionFrameCaptured) {
+      await captureFrame(page, paths.actionFramePath);
+      actionFrameCaptured = true;
+    }
+
+    const targetMilliseconds = (scene.end - scene.start) * 1_000 + 500;
+    const remainingMilliseconds = Math.max(250, targetMilliseconds - (now() - recordingStartedAt));
+    await page.waitForTimeout(remainingMilliseconds);
+    await captureFrame(page, paths.endFramePath);
+    if (scene.id === 'export') {
+      exportedMarkdown = await readExportedMarkdown(page, fixtures.exportPath);
+    }
+
+    collectStructuredMockDiagnostics(state, diagnostics);
+    assertCleanCaptureDiagnostics(diagnostics, scene.id);
+  } catch (error) {
+    captureError = error;
+  }
+
+  try {
+    await context?.close();
+  } catch (closeError) {
+    if (captureError !== undefined) {
+      throw combineCaptureAndCloseErrors(scene.id, captureError, closeError);
+    }
+    throw closeError;
+  }
+  if (captureError !== undefined) throw captureError;
+
+  await persistVideo(video, paths.videoPath, replaceFile);
+  const mediaProbe = await probeMediaFile(paths.videoPath);
+  const durationSeconds = requiredMediaDuration(mediaProbe.durationSeconds, paths.videoPath);
+  const contentStartOffsetSeconds = Math.max(
+    0,
+    ((contentStartAt ?? recordingOriginAt) - recordingOriginAt) / 1_000,
+  );
+  const result: SceneCaptureResult = {
+    scene: scene.id,
+    aspect,
+    paths,
+    contentStartOffsetSeconds,
+    durationSeconds,
+    diagnostics,
+    invokeCommands: state?.invokeLog.map((entry) => entry.command) ?? [],
+    ...(exportedMarkdown ? { exportedMarkdown } : {}),
+  };
+  const metadata = {
+    scene: result.scene,
+    aspect: result.aspect,
+    contentStartOffsetSeconds: result.contentStartOffsetSeconds,
+    durationSeconds: result.durationSeconds,
+    diagnostics: result.diagnostics,
+    invokeCommands: result.invokeCommands,
+  };
+  await writeFile(paths.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, 'utf8');
+  return result;
+}
+
+/** 无论浏览器关闭是否失败，都保证继续停止 Vite 服务，并保留首个错误。 */
+export async function cleanupCaptureResources(
+  browser: Browser | undefined,
+  server: DemoServer | undefined,
+  stopServer: typeof stopDemoServer = stopDemoServer,
+): Promise<void> {
+  let firstError: unknown;
+  try {
+    await browser?.close();
+  } catch (error) {
+    firstError = error;
+  }
+
+  try {
+    if (server) await stopServer(server);
+  } catch (error) {
+    if (firstError === undefined) firstError = error;
+  }
+
+  if (firstError !== undefined) throw firstError;
+}
+
+export async function captureAllScenes(
+  options: CaptureAllScenesOptions,
+): Promise<SceneCaptureResult[]> {
+  const aspects = options.aspects ?? ['16x9', '9x16'];
+  const sceneIds = options.sceneIds ?? STORYBOARD.map((scene) => scene.id);
+  const baseUrl = options.baseUrl ?? DEMO_BASE_URL;
+  let server: DemoServer | undefined;
+  let browser: Browser | undefined;
+
+  try {
+    server = await startDemoServer({ cwd: options.cwd, baseUrl });
+    browser = await launchDemoBrowser();
+    const results: SceneCaptureResult[] = [];
+    for (const aspect of aspects) {
+      for (const sceneId of sceneIds) {
+        const scene = findScene(sceneId);
+        results.push(await recordScene(scene, aspect, options.outputDir, {
+          browser,
+          baseUrl,
+        }));
+      }
+    }
+    return results;
+  } finally {
+    await cleanupCaptureResources(browser, server);
+  }
+}

--- a/scripts/product-demo/cli.test.ts
+++ b/scripts/product-demo/cli.test.ts
@@ -1,0 +1,545 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  BUILD_COMMAND_ORDER,
+  buildValidationSourceTextFiles,
+  createCachedKeyframeOcrRunner,
+  createDemoPaths,
+  assertCompleteCaptureDiagnosticEntries,
+  loadCompositionCaptureMetadata,
+  mergeCaptureDiagnosticEntries,
+  parseCliArgs,
+  runCli,
+  writeCaptureSupportFiles,
+  type CliDependencies,
+  type DemoCommand,
+} from './cli.ts';
+import type { ExtractKeyframeOcrOptions, KeyframeOcrResult } from './ocr.ts';
+import { STORYBOARD } from './storyboard.ts';
+import type { SceneCaptureResult } from './capture.ts';
+import type { KeyframeOcrFrame } from './validate.ts';
+
+function createDependencies(calls: string[] = []): CliDependencies {
+  const record = (command: DemoCommand) => async () => {
+    calls.push(command);
+  };
+  return {
+    check: record('check'),
+    capture: record('capture'),
+    subtitles: record('subtitles'),
+    audio: record('audio'),
+    compose: record('compose'),
+    validate: record('validate'),
+  };
+}
+
+test('解析七个受支持的产品演示命令', () => {
+  for (const command of [
+    'check',
+    'capture',
+    'subtitles',
+    'audio',
+    'compose',
+    'validate',
+    'build',
+  ] as const) {
+    assert.deepEqual(parseCliArgs([command]), { command });
+  }
+});
+
+test('capture 支持限定单个 timeline 分镜和 16x9 画幅', () => {
+  assert.deepEqual(
+    parseCliArgs(['capture', '--scene', 'timeline', '--aspect', '16x9']),
+    { command: 'capture', scene: 'timeline', aspect: '16x9' },
+  );
+});
+
+test('capture 接受全部合法分镜和两种画幅', () => {
+  for (const scene of [
+    'hook',
+    'timeline',
+    'report',
+    'assistant',
+    'privacy',
+    'export',
+    'outro',
+  ]) {
+    assert.equal(parseCliArgs(['capture', '--scene', scene]).scene, scene);
+  }
+  assert.equal(parseCliArgs(['capture', '--aspect', '9x16']).aspect, '9x16');
+});
+
+test('未知命令、缺失命令和无效参数会给出明确错误', () => {
+  assert.throws(() => parseCliArgs([]), /缺少命令.*check.*capture/u);
+  assert.throws(() => parseCliArgs(['publish']), /未知命令.*publish/u);
+  assert.throws(
+    () => parseCliArgs(['capture', '--scene', 'missing']),
+    /无效分镜.*missing/u,
+  );
+  assert.throws(
+    () => parseCliArgs(['capture', '--aspect', 'square']),
+    /无效画幅.*square/u,
+  );
+  assert.throws(
+    () => parseCliArgs(['capture', '--scene']),
+    /--scene.*缺少值/u,
+  );
+  assert.throws(
+    () => parseCliArgs(['compose', '--aspect', '16x9']),
+    /compose.*不支持参数/u,
+  );
+  assert.throws(
+    () => parseCliArgs(['capture', '--unknown', 'value']),
+    /未知参数.*--unknown/u,
+  );
+});
+
+test('恶意参数在调用依赖前被拒绝，不会进入任何录制或合成步骤', async () => {
+  const calls: string[] = [];
+  await assert.rejects(
+    runCli(['capture', '--scene', 'timeline; touch /tmp/unsafe'], {
+      cwd: '/workspace/work-review',
+      dependencies: createDependencies(calls),
+    }),
+    /无效分镜/u,
+  );
+  assert.deepEqual(calls, []);
+});
+
+test('所有生成路径都集中在仓库 artifacts/product-demo 目录', () => {
+  const cwd = path.resolve('/workspace/work-review');
+  const paths = createDemoPaths(cwd);
+  const expectedRoot = path.join(cwd, 'artifacts', 'product-demo');
+
+  assert.equal(paths.root, expectedRoot);
+  for (const artifactPath of Object.values(paths)) {
+    assert.equal(
+      artifactPath === expectedRoot || artifactPath.startsWith(`${expectedRoot}${path.sep}`),
+      true,
+      `${artifactPath} 必须位于 ${expectedRoot}`,
+    );
+  }
+});
+
+test('命令通过可注入依赖执行，单元测试不会真实录制或合成', async () => {
+  const calls: string[] = [];
+  const dependencies = createDependencies(calls);
+
+  await runCli(['capture', '--scene', 'timeline', '--aspect', '16x9'], {
+    cwd: '/workspace/work-review',
+    dependencies,
+  });
+
+  assert.deepEqual(calls, ['capture']);
+});
+
+test('build 严格按 check → capture → subtitles → audio → compose → validate 执行', async () => {
+  const calls: string[] = [];
+  assert.deepEqual(BUILD_COMMAND_ORDER, [
+    'check',
+    'capture',
+    'subtitles',
+    'audio',
+    'compose',
+    'validate',
+  ]);
+
+  await runCli(['build'], {
+    cwd: '/workspace/work-review',
+    dependencies: createDependencies(calls),
+  });
+
+  assert.deepEqual(calls, BUILD_COMMAND_ORDER);
+});
+
+test('每个非 build 命令只调用对应依赖一次', async () => {
+  for (const command of BUILD_COMMAND_ORDER) {
+    const calls: string[] = [];
+    await runCli([command], {
+      cwd: '/workspace/work-review',
+      dependencies: createDependencies(calls),
+    });
+    assert.deepEqual(calls, [command]);
+  }
+});
+
+test('package scripts 暴露完整产品演示命令且单元测试有 60 秒超时', async () => {
+  const packageJson = JSON.parse(await readFile('package.json', 'utf8')) as {
+    scripts: Record<string, string>;
+  };
+
+  assert.equal(
+    packageJson.scripts['demo:check'],
+    'node --test-timeout=60000 --import tsx --test "scripts/product-demo/*.test.ts"',
+  );
+  for (const command of ['capture', 'subtitles', 'audio', 'compose', 'validate', 'build']) {
+    assert.equal(
+      packageJson.scripts[`demo:${command}`],
+      `node --import tsx scripts/product-demo/cli.ts ${command}`,
+    );
+  }
+});
+
+test('gitignore 忽略产品演示大体积产物目录', async () => {
+  const gitignore = await readFile('.gitignore', 'utf8');
+  assert.match(gitignore, /^\/artifacts\/product-demo\/$/mu);
+});
+
+
+test('合成按故事板顺序读取七个录制 metadata 的内容起点和真实源时长', async () => {
+  const intermediate = await mkdtemp(path.join(tmpdir(), 'work-review-cli-metadata-'));
+  const aspectDir = path.join(intermediate, '16x9');
+  await mkdir(aspectDir, { recursive: true });
+  const sceneIds = ['hook', 'timeline', 'report'] as const;
+
+  await Promise.all(sceneIds.map((scene, index) => writeFile(
+    path.join(aspectDir, `${scene}.json`),
+    JSON.stringify({
+      scene,
+      aspect: '16x9',
+      contentStartOffsetSeconds: 0.4 + index * 0.1,
+      durationSeconds: 9 + index,
+    }),
+    'utf8',
+  )));
+
+  const result = await loadCompositionCaptureMetadata({
+    intermediateDir: intermediate,
+    aspect: '16x9',
+    sceneIds,
+  });
+
+  assert.deepEqual(result.sourceStartOffsetsSeconds, [0.4, 0.5, 0.6000000000000001]);
+  assert.deepEqual(result.sourceDurationsSeconds, [9, 10, 11]);
+  assert.deepEqual(result.metadataPaths, sceneIds.map((scene) => path.join(aspectDir, `${scene}.json`)));
+});
+
+test('合成拒绝缺失、错位或无效的录制 metadata', async (t) => {
+  const cases = [
+    {
+      name: '缺失文件',
+      value: undefined,
+      expected: /缺少分镜 metadata.*hook/u,
+    },
+    {
+      name: '分镜错位',
+      value: { scene: 'timeline', aspect: '16x9', contentStartOffsetSeconds: 0.2, durationSeconds: 9 },
+      expected: /分镜不匹配.*hook.*timeline/u,
+    },
+    {
+      name: '画幅错位',
+      value: { scene: 'hook', aspect: '9x16', contentStartOffsetSeconds: 0.2, durationSeconds: 9 },
+      expected: /画幅不匹配.*16x9.*9x16/u,
+    },
+    {
+      name: '负数起点',
+      value: { scene: 'hook', aspect: '16x9', contentStartOffsetSeconds: -0.1, durationSeconds: 9 },
+      expected: /内容起点.*非负有限数/u,
+    },
+    {
+      name: '起点超出源时长',
+      value: { scene: 'hook', aspect: '16x9', contentStartOffsetSeconds: 9, durationSeconds: 9 },
+      expected: /内容起点.*小于源时长/u,
+    },
+    {
+      name: '非正源时长',
+      value: { scene: 'hook', aspect: '16x9', contentStartOffsetSeconds: 0, durationSeconds: 0 },
+      expected: /源时长.*正有限数/u,
+    },
+  ] as const;
+
+  for (const entry of cases) {
+    await t.test(entry.name, async () => {
+      const intermediate = await mkdtemp(path.join(tmpdir(), 'work-review-cli-invalid-metadata-'));
+      const aspectDir = path.join(intermediate, '16x9');
+      await mkdir(aspectDir, { recursive: true });
+      if (entry.value) {
+        await writeFile(path.join(aspectDir, 'hook.json'), JSON.stringify(entry.value), 'utf8');
+      }
+
+      await assert.rejects(
+        loadCompositionCaptureMetadata({
+          intermediateDir: intermediate,
+          aspect: '16x9',
+          sceneIds: ['hook'],
+        }),
+        entry.expected,
+      );
+    });
+  }
+});
+
+
+test('局部重录按画幅和分镜合并诊断，不覆盖其他十三个镜头', () => {
+  const existing: Array<{ scene: 'hook' | 'timeline'; aspect: '16x9' | '9x16'; pageErrors: readonly string[] }> = [
+    { scene: 'hook', aspect: '16x9', pageErrors: ['old'] },
+    { scene: 'timeline', aspect: '16x9', pageErrors: [] },
+    { scene: 'hook', aspect: '9x16', pageErrors: [] },
+  ] as const;
+  const incoming: Array<{ scene: 'hook' | 'timeline'; aspect: '16x9' | '9x16'; pageErrors: readonly string[] }> = [
+    { scene: 'hook', aspect: '16x9', pageErrors: [] },
+  ] as const;
+
+  assert.deepEqual(mergeCaptureDiagnosticEntries(existing, incoming), [
+    { scene: 'hook', aspect: '16x9', pageErrors: [] },
+    { scene: 'timeline', aspect: '16x9', pageErrors: [] },
+    { scene: 'hook', aspect: '9x16', pageErrors: [] },
+  ]);
+});
+
+test('完整录制诊断必须恰好覆盖横竖屏七个镜头且全部无错误', () => {
+  const scenes = ['hook', 'timeline', 'report', 'assistant', 'privacy', 'export', 'outro'] as const;
+  const consoleEntries = (['16x9', '9x16'] as const).flatMap((aspect) => scenes.map((scene) => ({
+    scene,
+    aspect,
+    pageErrors: [],
+    consoleErrors: [],
+    unhandledCommands: [],
+    invokeCommands: [],
+  })));
+  const networkEntries = consoleEntries.map(({ scene, aspect }) => ({
+    scene,
+    aspect,
+    blockedRequests: [],
+    policy: 'same-origin-data-blob-only',
+  }));
+
+  assert.doesNotThrow(() => assertCompleteCaptureDiagnosticEntries(consoleEntries, networkEntries));
+  assert.throws(
+    () => assertCompleteCaptureDiagnosticEntries(consoleEntries.slice(1), networkEntries),
+    /控制台诊断.*缺少.*16x9.*hook/u,
+  );
+  assert.throws(
+    () => assertCompleteCaptureDiagnosticEntries(
+      consoleEntries.map((entry, index) => index === 0 ? { ...entry, pageErrors: ['boom'] } : entry),
+      networkEntries,
+    ),
+    /hook.*pageErrors.*boom/u,
+  );
+  assert.throws(
+    () => assertCompleteCaptureDiagnosticEntries(
+      consoleEntries,
+      networkEntries.map((entry, index) => index === 0 ? { ...entry, blockedRequests: ['https:\/\/example.com'] } : entry),
+    ),
+    /hook.*blockedRequests.*example.com/u,
+  );
+});
+
+test('诊断合并拒绝重复或未知的画幅分镜组合', () => {
+  assert.throws(
+    () => mergeCaptureDiagnosticEntries([], [
+      { scene: 'hook', aspect: '16x9' },
+      { scene: 'hook', aspect: '16x9' },
+    ]),
+    /重复.*16x9.*hook/u,
+  );
+  assert.throws(
+    () => mergeCaptureDiagnosticEntries([], [
+      { scene: 'missing', aspect: '16x9' } as never,
+    ]),
+    /无效.*missing/u,
+  );
+});
+
+
+test('交付隐私扫描包含三个字幕文件和横竖屏全部十四个录制 metadata', () => {
+  const paths = createDemoPaths('/workspace/work-review');
+  const sourceTextFiles = buildValidationSourceTextFiles(paths);
+
+  assert.equal(sourceTextFiles.length, 17);
+  assert.deepEqual(sourceTextFiles.slice(0, 3), [
+    'work-review-demo-zh.srt',
+    'work-review-demo-en.srt',
+    'work-review-demo-zh-en.srt',
+  ]);
+  assert.deepEqual(
+    sourceTextFiles.slice(3),
+    (['16x9', '9x16'] as const).flatMap((aspect) => STORYBOARD.map((scene) => (
+      `intermediate/${aspect}/${scene.id}.json`
+    ))),
+  );
+});
+
+test('真实 OCR 适配器映射验证关键帧、返回对应证据并在完整性复验时复用结果', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'work-review-cli-ocr-'));
+  const outputDir = path.join(root, 'ocr');
+  const frames: KeyframeOcrFrame[] = [
+    {
+      aspect: '16x9',
+      scene: 'hook',
+      phase: 'start',
+      relativePath: 'intermediate/16x9/hook-start.png',
+      absolutePath: path.join(root, 'hook-start.png'),
+      imageBytes: new Uint8Array([1]),
+    },
+    {
+      aspect: '9x16',
+      scene: 'outro',
+      phase: 'end',
+      relativePath: 'intermediate/9x16/outro-end.png',
+      absolutePath: path.join(root, 'outro-end.png'),
+      imageBytes: new Uint8Array([2]),
+    },
+  ];
+  let extractionCalls = 0;
+  const extract = async (options: ExtractKeyframeOcrOptions): Promise<KeyframeOcrResult> => {
+    extractionCalls += 1;
+    assert.equal(options.outputDir, outputDir);
+    assert.deepEqual(options.inputs, [
+      { aspect: '16x9', scene: 'hook', frame: 'start', imagePath: frames[0]!.absolutePath },
+      { aspect: '9x16', scene: 'outro', frame: 'end', imagePath: frames[1]!.absolutePath },
+    ]);
+    const textFiles = [path.join(outputDir, 'hook.txt'), path.join(outputDir, 'outro.txt')];
+    await mkdir(outputDir, { recursive: true });
+    await Promise.all([
+      writeFile(textFiles[0]!, '今天完成安全演示\n', 'utf8'),
+      writeFile(textFiles[1]!, '记录默认留在设备上\n', 'utf8'),
+    ]);
+    return {
+      outputDir,
+      manifestPath: path.join(outputDir, 'manifest.json'),
+      textFiles,
+      manifest: {
+        schemaVersion: 1,
+        engine: 'macos-vision',
+        recognitionLanguages: ['zh-Hans', 'en-US'],
+        entryCount: 2,
+        entries: [
+          {
+            aspect: '16x9',
+            scene: 'hook',
+            frame: 'start',
+            sourceFile: '16x9/hook-start.png',
+            textFile: 'hook.txt',
+            characterCount: 8,
+          },
+          {
+            aspect: '9x16',
+            scene: 'outro',
+            frame: 'end',
+            sourceFile: '9x16/outro-end.png',
+            textFile: 'outro.txt',
+            characterCount: 10,
+          },
+        ],
+      },
+    };
+  };
+
+  try {
+    const runner = createCachedKeyframeOcrRunner(outputDir, extract);
+    const first = await runner(frames);
+    const second = await runner(frames.map((frame) => ({ ...frame })));
+
+    assert.equal(extractionCalls, 1);
+    assert.deepEqual(second, first);
+    assert.deepEqual(first, {
+      available: true,
+      engine: 'macos-vision',
+      evidence: [
+        {
+          relativePath: 'intermediate/16x9/hook-start.png',
+          text: '今天完成安全演示\n',
+        },
+        {
+          relativePath: 'intermediate/9x16/outro-end.png',
+          text: '记录默认留在设备上\n',
+        },
+      ],
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+
+function captureResult(
+  scene: SceneCaptureResult['scene'],
+  aspect: SceneCaptureResult['aspect'],
+  exportedMarkdown?: SceneCaptureResult['exportedMarkdown'],
+): SceneCaptureResult {
+  const base = `/tmp/work-review-demo/${aspect}/${scene}`;
+  return {
+    scene,
+    aspect,
+    paths: {
+      aspectDir: path.dirname(base),
+      videoPath: `${base}.webm`,
+      startFramePath: `${base}-start.png`,
+      actionFramePath: `${base}-action.png`,
+      endFramePath: `${base}-end.png`,
+      metadataPath: `${base}.json`,
+    },
+    contentStartOffsetSeconds: 0.5,
+    durationSeconds: 10,
+    diagnostics: {
+      pageErrors: [],
+      consoleErrors: [],
+      blockedRequests: [],
+      unhandledCommands: [],
+    },
+    invokeCommands: [],
+    ...(exportedMarkdown ? { exportedMarkdown } : {}),
+  };
+}
+
+test('录制支持文件写入横竖屏一致的 UI 实际导出 Markdown', async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), 'work-review-cli-export-'));
+  const paths = createDemoPaths(cwd);
+  const content = '# 2026-08-12 日报\n\n来自 UI 导出';
+  const context = { cwd, paths, args: { command: 'capture' as const } };
+
+  try {
+    await writeCaptureSupportFiles(context, [
+      captureResult('export', '16x9', { fileName: '2026-08-12.md', content }),
+      captureResult('export', '9x16', { fileName: '2026-08-12.md', content }),
+    ]);
+    assert.equal(await readFile(paths.exportMarkdown, 'utf8'), `${content}\n`);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test('完整录制缺少任一画幅的 UI 实际导出 Markdown 时阻断', async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), 'work-review-cli-export-missing-'));
+  const paths = createDemoPaths(cwd);
+  const context = { cwd, paths, args: { command: 'capture' as const } };
+
+  try {
+    await assert.rejects(
+      writeCaptureSupportFiles(context, [
+        captureResult('export', '16x9', {
+          fileName: '2026-08-12.md',
+          content: '# 日报',
+        }),
+        captureResult('export', '9x16'),
+      ]),
+      /完整录制.*9x16.*实际导出/u,
+    );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test('局部重录非 export 镜头不会覆盖已有导出 Markdown', async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), 'work-review-cli-export-preserve-'));
+  const paths = createDemoPaths(cwd);
+  const context = {
+    cwd,
+    paths,
+    args: { command: 'capture' as const, scene: 'hook' as const, aspect: '16x9' as const },
+  };
+
+  try {
+    await mkdir(paths.exports, { recursive: true });
+    await writeFile(paths.exportMarkdown, '保留现有 UI 导出\n', 'utf8');
+    await writeCaptureSupportFiles(context, [captureResult('hook', '16x9')]);
+    assert.equal(await readFile(paths.exportMarkdown, 'utf8'), '保留现有 UI 导出\n');
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});

--- a/scripts/product-demo/cli.ts
+++ b/scripts/product-demo/cli.ts
@@ -1,0 +1,787 @@
+import { spawn } from 'node:child_process';
+import {
+  copyFile,
+  mkdir,
+  readFile,
+  writeFile,
+} from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import type { ExtractKeyframeOcrOptions, KeyframeOcrResult } from './ocr.ts';
+import type { DemoAspect, StoryboardSceneId } from './types.ts';
+import type { KeyframeOcrFrame, KeyframeOcrRunner } from './validate.ts';
+
+export type DemoCommand =
+  | 'check'
+  | 'capture'
+  | 'subtitles'
+  | 'audio'
+  | 'compose'
+  | 'validate'
+  | 'build';
+
+export interface ParsedCliArgs {
+  command: DemoCommand;
+  scene?: StoryboardSceneId;
+  aspect?: DemoAspect;
+}
+
+export interface DemoPaths {
+  root: string;
+  intermediate: string;
+  subtitleSources: string;
+  subtitleOverlays: string;
+  audio: string;
+  voiceover: string;
+  logs: string;
+  exports: string;
+  voiceoverMix: string;
+  backgroundMusic: string;
+  soundEffects: string;
+  finalMix: string;
+  consoleLog: string;
+  networkLog: string;
+  exportMarkdown: string;
+  subtitleZh: string;
+  subtitleEn: string;
+  subtitleBilingual: string;
+  video16x9: string;
+  video9x16: string;
+  cover16x9: string;
+  cover9x16: string;
+}
+
+export interface CliCommandContext {
+  cwd: string;
+  paths: DemoPaths;
+  args: ParsedCliArgs;
+}
+
+export interface CliDependencies {
+  check(context: CliCommandContext): Promise<void>;
+  capture(context: CliCommandContext): Promise<void>;
+  subtitles(context: CliCommandContext): Promise<void>;
+  audio(context: CliCommandContext): Promise<void>;
+  compose(context: CliCommandContext): Promise<void>;
+  validate(context: CliCommandContext): Promise<void>;
+}
+
+export interface RunCliOptions {
+  cwd?: string;
+  dependencies?: CliDependencies;
+}
+
+export const BUILD_COMMAND_ORDER = [
+  'check',
+  'capture',
+  'subtitles',
+  'audio',
+  'compose',
+  'validate',
+] as const satisfies readonly Exclude<DemoCommand, 'build'>[];
+
+const COMMANDS = new Set<DemoCommand>([...BUILD_COMMAND_ORDER, 'build']);
+const SCENE_ORDER = [
+  'hook',
+  'timeline',
+  'report',
+  'assistant',
+  'privacy',
+  'export',
+  'outro',
+] as const satisfies readonly StoryboardSceneId[];
+const ASPECT_ORDER = ['16x9', '9x16'] as const satisfies readonly DemoAspect[];
+const SCENES = new Set<StoryboardSceneId>(SCENE_ORDER);
+const ASPECTS = new Set<DemoAspect>(ASPECT_ORDER);
+
+export function createDemoPaths(cwd: string): DemoPaths {
+  const root = path.resolve(cwd, 'artifacts', 'product-demo');
+  const intermediate = path.join(root, 'intermediate');
+  const subtitleSources = path.join(intermediate, 'subtitles');
+  const subtitleOverlays = path.join(intermediate, 'subtitle-overlays');
+  const audio = path.join(intermediate, 'audio');
+  const voiceover = path.join(audio, 'voiceover');
+  const logs = path.join(intermediate, 'logs');
+  const exports = path.join(intermediate, 'exports');
+
+  return {
+    root,
+    intermediate,
+    subtitleSources,
+    subtitleOverlays,
+    audio,
+    voiceover,
+    logs,
+    exports,
+    voiceoverMix: path.join(voiceover, 'voiceover.wav'),
+    backgroundMusic: path.join(audio, 'background-music.wav'),
+    soundEffects: path.join(audio, 'sound-effects.wav'),
+    finalMix: path.join(audio, 'work-review-demo-mix.wav'),
+    consoleLog: path.join(logs, 'playwright-console.json'),
+    networkLog: path.join(logs, 'playwright-network.json'),
+    exportMarkdown: path.join(exports, '2026-08-12.md'),
+    subtitleZh: path.join(root, 'work-review-demo-zh.srt'),
+    subtitleEn: path.join(root, 'work-review-demo-en.srt'),
+    subtitleBilingual: path.join(root, 'work-review-demo-zh-en.srt'),
+    video16x9: path.join(root, 'work-review-demo-16x9.mp4'),
+    video9x16: path.join(root, 'work-review-demo-9x16.mp4'),
+    cover16x9: path.join(root, 'work-review-demo-cover-16x9.png'),
+    cover9x16: path.join(root, 'work-review-demo-cover-9x16.png'),
+  };
+}
+
+function requireOptionValue(argv: readonly string[], index: number, option: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) throw new Error(`参数 ${option} 缺少值`);
+  return value;
+}
+
+export function parseCliArgs(argv: readonly string[]): ParsedCliArgs {
+  const commandValue = argv[0];
+  if (!commandValue) {
+    throw new Error(
+      '缺少命令。支持：check、capture、subtitles、audio、compose、validate、build',
+    );
+  }
+  if (!COMMANDS.has(commandValue as DemoCommand)) {
+    throw new Error(`未知命令：${commandValue}`);
+  }
+
+  const command = commandValue as DemoCommand;
+  if (command !== 'capture') {
+    if (argv.length > 1) {
+      throw new Error(`${command} 命令不支持参数：${argv.slice(1).join(' ')}`);
+    }
+    return { command };
+  }
+
+  let scene: StoryboardSceneId | undefined;
+  let aspect: DemoAspect | undefined;
+  for (let index = 1; index < argv.length; index += 1) {
+    const option = argv[index];
+    if (option === '--scene') {
+      if (scene) throw new Error('参数 --scene 不得重复');
+      const value = requireOptionValue(argv, index, option);
+      if (!SCENES.has(value as StoryboardSceneId)) throw new Error(`无效分镜：${value}`);
+      scene = value as StoryboardSceneId;
+      index += 1;
+      continue;
+    }
+    if (option === '--aspect') {
+      if (aspect) throw new Error('参数 --aspect 不得重复');
+      const value = requireOptionValue(argv, index, option);
+      if (!ASPECTS.has(value as DemoAspect)) throw new Error(`无效画幅：${value}`);
+      aspect = value as DemoAspect;
+      index += 1;
+      continue;
+    }
+    throw new Error(`未知参数：${option}`);
+  }
+
+  return { command, ...(scene ? { scene } : {}), ...(aspect ? { aspect } : {}) };
+}
+
+function runProcess(binary: string, args: readonly string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(binary, [...args], {
+      cwd,
+      shell: false,
+      stdio: 'inherit',
+      windowsHide: true,
+    });
+    child.once('error', (error) => reject(new Error(`无法启动 ${binary}：${error.message}`)));
+    child.once('close', (exitCode, signal) => {
+      if (exitCode === 0) {
+        resolve();
+        return;
+      }
+      const status = exitCode === null ? `信号 ${signal ?? 'unknown'}` : `退出码 ${exitCode}`;
+      reject(new Error(`命令 ${binary} 执行失败（${status}）`));
+    });
+  });
+}
+
+function relativeArtifactPath(paths: DemoPaths, absolutePath: string): string {
+  const relative = path.relative(paths.root, absolutePath);
+  if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`产物路径逃逸 artifacts/product-demo：${absolutePath}`);
+  }
+  return relative.split(path.sep).join('/');
+}
+
+export interface CaptureDiagnosticIdentity {
+  scene: StoryboardSceneId;
+  aspect: DemoAspect;
+}
+
+function captureDiagnosticKey(entry: CaptureDiagnosticIdentity): string {
+  return `${entry.aspect}:${entry.scene}`;
+}
+
+function assertCaptureDiagnosticIdentity(
+  value: unknown,
+  label: string,
+): asserts value is CaptureDiagnosticIdentity & Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label}必须是对象`);
+  }
+  const entry = value as Record<string, unknown>;
+  if (!SCENES.has(entry.scene as StoryboardSceneId)) {
+    throw new Error(`${label}包含无效分镜：${String(entry.scene)}`);
+  }
+  if (!ASPECTS.has(entry.aspect as DemoAspect)) {
+    throw new Error(`${label}包含无效画幅：${String(entry.aspect)}`);
+  }
+}
+
+function diagnosticMap<T extends CaptureDiagnosticIdentity>(
+  entries: readonly T[],
+  label: string,
+): Map<string, T> {
+  const result = new Map<string, T>();
+  entries.forEach((entry, index) => {
+    assertCaptureDiagnosticIdentity(entry, `${label}第 ${index + 1} 项`);
+    const key = captureDiagnosticKey(entry);
+    if (result.has(key)) throw new Error(`${label}存在重复画幅分镜组合：${entry.aspect} ${entry.scene}`);
+    result.set(key, entry);
+  });
+  return result;
+}
+
+/** 局部重录时按画幅和分镜覆盖对应诊断，同时保留其他镜头。 */
+export function mergeCaptureDiagnosticEntries<T extends CaptureDiagnosticIdentity>(
+  existing: readonly T[],
+  incoming: readonly T[],
+): T[] {
+  const merged = diagnosticMap(existing, '已有诊断');
+  const updates = diagnosticMap(incoming, '新增诊断');
+  for (const [key, entry] of updates) merged.set(key, entry);
+  return ASPECT_ORDER.flatMap((aspect) => SCENE_ORDER.flatMap((scene) => {
+    const entry = merged.get(`${aspect}:${scene}`);
+    return entry ? [entry] : [];
+  }));
+}
+
+function requireDiagnosticArray(
+  entry: CaptureDiagnosticIdentity & Record<string, unknown>,
+  field: string,
+  label: string,
+): readonly unknown[] {
+  const value = entry[field];
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} ${entry.aspect} ${entry.scene} 的 ${field} 必须是数组`);
+  }
+  return value;
+}
+
+/** 最终交付前强制确认横竖屏七镜头的浏览器诊断完整且为空。 */
+export function assertCompleteCaptureDiagnosticEntries(
+  consoleEntries: readonly unknown[],
+  networkEntries: readonly unknown[],
+): void {
+  const consoleMap = diagnosticMap(
+    consoleEntries as Array<CaptureDiagnosticIdentity & Record<string, unknown>>,
+    '控制台诊断',
+  );
+  const networkMap = diagnosticMap(
+    networkEntries as Array<CaptureDiagnosticIdentity & Record<string, unknown>>,
+    '网络诊断',
+  );
+
+  for (const aspect of ASPECT_ORDER) {
+    for (const scene of SCENE_ORDER) {
+      const key = `${aspect}:${scene}`;
+      const consoleEntry = consoleMap.get(key);
+      if (!consoleEntry) throw new Error(`控制台诊断缺少 ${aspect} ${scene}`);
+      const networkEntry = networkMap.get(key);
+      if (!networkEntry) throw new Error(`网络诊断缺少 ${aspect} ${scene}`);
+
+      for (const field of ['pageErrors', 'consoleErrors', 'unhandledCommands'] as const) {
+        const values = requireDiagnosticArray(consoleEntry, field, '控制台诊断');
+        if (values.length > 0) {
+          throw new Error(`${aspect} ${scene} 的 ${field} 非空：${values.map(String).join('；')}`);
+        }
+      }
+      const blockedRequests = requireDiagnosticArray(networkEntry, 'blockedRequests', '网络诊断');
+      if (blockedRequests.length > 0) {
+        throw new Error(`${aspect} ${scene} 的 blockedRequests 非空：${blockedRequests.map(String).join('；')}`);
+      }
+    }
+  }
+}
+
+async function readDiagnosticEntries(filePath: string): Promise<Array<CaptureDiagnosticIdentity & Record<string, unknown>>> {
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`录制诊断 JSON 无效：${filePath}（${message}）`);
+  }
+  if (!Array.isArray(parsed)) throw new Error(`录制诊断必须是数组：${filePath}`);
+  parsed.forEach((entry, index) => assertCaptureDiagnosticIdentity(entry, `录制诊断第 ${index + 1} 项`));
+  return parsed as Array<CaptureDiagnosticIdentity & Record<string, unknown>>;
+}
+
+export interface CompositionCaptureMetadata {
+  metadataPaths: string[];
+  sourceStartOffsetsSeconds: number[];
+  sourceDurationsSeconds: number[];
+}
+
+export interface LoadCompositionCaptureMetadataOptions {
+  intermediateDir: string;
+  aspect: DemoAspect;
+  sceneIds: readonly StoryboardSceneId[];
+}
+
+function requireMetadataObject(value: unknown, metadataPath: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`分镜 metadata 必须是对象：${metadataPath}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+/** 按故事板顺序读取录制元数据，避免预卷进入正式成片。 */
+export async function loadCompositionCaptureMetadata(
+  options: LoadCompositionCaptureMetadataOptions,
+): Promise<CompositionCaptureMetadata> {
+  const metadataPaths: string[] = [];
+  const sourceStartOffsetsSeconds: number[] = [];
+  const sourceDurationsSeconds: number[] = [];
+
+  for (const expectedScene of options.sceneIds) {
+    const metadataPath = path.join(options.intermediateDir, options.aspect, `${expectedScene}.json`);
+    let raw: string;
+    try {
+      raw = await readFile(metadataPath, 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error(`缺少分镜 metadata：${expectedScene}（${options.aspect}）`);
+      }
+      throw error;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`分镜 metadata JSON 无效：${expectedScene}（${message}）`);
+    }
+    const metadata = requireMetadataObject(parsed, metadataPath);
+
+    if (metadata.scene !== expectedScene) {
+      throw new Error(
+        `分镜 metadata 分镜不匹配：期望 ${expectedScene}，实际 ${String(metadata.scene)}`,
+      );
+    }
+    if (metadata.aspect !== options.aspect) {
+      throw new Error(
+        `分镜 metadata 画幅不匹配：期望 ${options.aspect}，实际 ${String(metadata.aspect)}`,
+      );
+    }
+
+    const durationSeconds = metadata.durationSeconds;
+    if (typeof durationSeconds !== 'number' || !Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+      throw new Error(`分镜 ${expectedScene} 源时长必须是正有限数`);
+    }
+    const contentStartOffsetSeconds = metadata.contentStartOffsetSeconds;
+    if (
+      typeof contentStartOffsetSeconds !== 'number'
+      || !Number.isFinite(contentStartOffsetSeconds)
+      || contentStartOffsetSeconds < 0
+    ) {
+      throw new Error(`分镜 ${expectedScene} 内容起点必须是非负有限数`);
+    }
+    if (contentStartOffsetSeconds >= durationSeconds) {
+      throw new Error(`分镜 ${expectedScene} 内容起点必须小于源时长`);
+    }
+
+    metadataPaths.push(metadataPath);
+    sourceStartOffsetsSeconds.push(contentStartOffsetSeconds);
+    sourceDurationsSeconds.push(durationSeconds);
+  }
+
+  return { metadataPaths, sourceStartOffsetsSeconds, sourceDurationsSeconds };
+}
+
+async function runCheck(context: CliCommandContext): Promise<void> {
+  const [{ validateStoryboard }, { createDemoFixtures }, privacy] = await Promise.all([
+    import('./storyboard.ts'),
+    import('./fixtures.ts'),
+    import('./privacy.ts'),
+  ]);
+  validateStoryboard();
+  privacy.assertNoSensitiveContent(
+    privacy.scanDemoObject(createDemoFixtures(), 'demo-fixtures'),
+  );
+  await runProcess(process.execPath, [
+    '--test-timeout=60000',
+    '--import',
+    'tsx',
+    '--test',
+    'scripts/product-demo/*.test.ts',
+  ], context.cwd);
+}
+
+export async function writeCaptureSupportFiles(
+  context: CliCommandContext,
+  results: readonly Awaited<ReturnType<typeof import('./capture.ts')['captureAllScenes']>>[number][],
+): Promise<void> {
+  await Promise.all([
+    mkdir(context.paths.logs, { recursive: true }),
+    mkdir(context.paths.exports, { recursive: true }),
+  ]);
+
+  const consoleEntries = results.map((result) => ({
+    scene: result.scene,
+    aspect: result.aspect,
+    pageErrors: result.diagnostics.pageErrors,
+    consoleErrors: result.diagnostics.consoleErrors,
+    unhandledCommands: result.diagnostics.unhandledCommands,
+    invokeCommands: result.invokeCommands,
+  }));
+  const networkEntries = results.map((result) => ({
+    scene: result.scene,
+    aspect: result.aspect,
+    blockedRequests: result.diagnostics.blockedRequests,
+    policy: 'same-origin-data-blob-only',
+  }));
+
+  const fullCapture = !context.args.scene && !context.args.aspect;
+  const [existingConsoleEntries, existingNetworkEntries] = fullCapture
+    ? [[], []]
+    : await Promise.all([
+        readDiagnosticEntries(context.paths.consoleLog),
+        readDiagnosticEntries(context.paths.networkLog),
+      ]);
+  const mergedConsoleEntries = mergeCaptureDiagnosticEntries(existingConsoleEntries, consoleEntries);
+  const mergedNetworkEntries = mergeCaptureDiagnosticEntries(existingNetworkEntries, networkEntries);
+
+  const exportResults = results.filter((result) => result.scene === 'export');
+  if (fullCapture) {
+    for (const aspect of ASPECT_ORDER) {
+      if (!exportResults.some((result) => result.aspect === aspect && result.exportedMarkdown)) {
+        throw new Error(`完整录制缺少 ${aspect} export 镜头的 UI 实际导出 Markdown`);
+      }
+    }
+  }
+
+  const exportedMarkdown = exportResults
+    .map((result) => result.exportedMarkdown)
+    .filter((value) => value !== undefined);
+  const expectedFileName = path.basename(context.paths.exportMarkdown);
+  for (const exported of exportedMarkdown) {
+    if (exported.fileName !== expectedFileName) {
+      throw new Error(`UI 实际导出文件名错误：期望 ${expectedFileName}，实际 ${exported.fileName}`);
+    }
+    if (!exported.content.trim()) throw new Error('UI 实际导出 Markdown 内容不能为空');
+  }
+  if (new Set(exportedMarkdown.map((value) => value.content)).size > 1) {
+    throw new Error('横竖屏 export 镜头的 UI 实际导出 Markdown 内容不一致');
+  }
+
+  const writes: Promise<void>[] = [
+    writeFile(context.paths.consoleLog, `${JSON.stringify(mergedConsoleEntries, null, 2)}
+`, 'utf8'),
+    writeFile(context.paths.networkLog, `${JSON.stringify(mergedNetworkEntries, null, 2)}
+`, 'utf8'),
+  ];
+  const capturedExport = exportedMarkdown[0];
+  if (capturedExport) {
+    writes.push(writeFile(
+      context.paths.exportMarkdown,
+      `${capturedExport.content.trimEnd()}
+`,
+      'utf8',
+    ));
+  }
+  await Promise.all(writes);
+}
+
+async function runCapture(context: CliCommandContext): Promise<void> {
+  const { captureAllScenes } = await import('./capture.ts');
+  const results = await captureAllScenes({
+    outputDir: context.paths.intermediate,
+    cwd: context.cwd,
+    ...(context.args.scene ? { sceneIds: [context.args.scene] } : {}),
+    ...(context.args.aspect ? { aspects: [context.args.aspect] } : {}),
+  });
+  await writeCaptureSupportFiles(context, results);
+}
+
+async function runSubtitles(context: CliCommandContext): Promise<void> {
+  const { writeSubtitleArtifacts } = await import('./subtitles.ts');
+  const generated = await writeSubtitleArtifacts(context.paths.subtitleSources);
+  await mkdir(context.paths.root, { recursive: true });
+  await Promise.all([
+    copyFile(generated.zh, context.paths.subtitleZh),
+    copyFile(generated.en, context.paths.subtitleEn),
+    copyFile(generated.bilingual, context.paths.subtitleBilingual),
+  ]);
+}
+
+async function runAudio(context: CliCommandContext): Promise<void> {
+  const [audio, { VOICEOVER_CUES }] = await Promise.all([
+    import('./audio.ts'),
+    import('./storyboard.ts'),
+  ]);
+  const voiceoverPath = await audio.buildVoiceover(VOICEOVER_CUES, {
+    outputDir: context.paths.voiceover,
+  });
+  const musicPath = await audio.buildBackgroundMusic(context.paths.backgroundMusic);
+  const effectsPath = await audio.buildSoundEffects(context.paths.soundEffects);
+  await audio.mixDemoAudio({
+    voiceoverPath,
+    musicPath,
+    effectsPath,
+    outputPath: context.paths.finalMix,
+    voiceoverCues: VOICEOVER_CUES,
+  });
+}
+
+async function runCompose(context: CliCommandContext): Promise<void> {
+  const [{ launchDemoBrowser }, composition, { STORYBOARD }] = await Promise.all([
+    import('./browser.ts'),
+    import('./compose.ts'),
+    import('./storyboard.ts'),
+  ]);
+  const browser = await launchDemoBrowser();
+
+  try {
+    for (const aspect of ['16x9', '9x16'] as const) {
+      const subtitlePngPaths = await composition.renderSubtitleOverlayPngs({
+        browser,
+        aspect,
+        outputDir: context.paths.subtitleOverlays,
+      });
+      const sceneVideoPaths = STORYBOARD.map((scene) => (
+        path.join(context.paths.intermediate, aspect, `${scene.id}.webm`)
+      ));
+      const captureMetadata = await loadCompositionCaptureMetadata({
+        intermediateDir: context.paths.intermediate,
+        aspect,
+        sceneIds: STORYBOARD.map((scene) => scene.id),
+      });
+      const outputPath = aspect === '16x9'
+        ? context.paths.video16x9
+        : context.paths.video9x16;
+      const coverPath = aspect === '16x9'
+        ? context.paths.cover16x9
+        : context.paths.cover9x16;
+
+      await composition.composeDemoVideo({
+        aspect,
+        sceneVideoPaths,
+        subtitlePngPaths,
+        mixPath: context.paths.finalMix,
+        outputPath,
+        sourceDurationsSeconds: captureMetadata.sourceDurationsSeconds,
+        sourceStartOffsetsSeconds: captureMetadata.sourceStartOffsetsSeconds,
+      });
+      await composition.renderCoverPng({
+        browser,
+        aspect,
+        outputPath: coverPath,
+        iconPath: path.join(context.cwd, 'public', 'icon.png'),
+      });
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+async function readPackageVersion(cwd: string): Promise<string> {
+  const value = JSON.parse(await readFile(path.join(cwd, 'package.json'), 'utf8')) as {
+    version?: unknown;
+  };
+  if (typeof value.version !== 'string' || !value.version.trim()) {
+    throw new Error('package.json 缺少有效版本号');
+  }
+  return value.version;
+}
+
+async function readGitCommit(cwd: string): Promise<string> {
+  const { runCommand } = await import('./ffmpeg.ts');
+  const result = await runCommand('git', ['rev-parse', 'HEAD'], { cwd });
+  const commit = result.stdout.trim();
+  if (!/^[0-9a-f]{40}$/u.test(commit)) throw new Error(`无法确定 Git commit：${commit}`);
+  return commit;
+}
+
+export function buildValidationSourceTextFiles(paths: DemoPaths): string[] {
+  const subtitleFiles = [paths.subtitleZh, paths.subtitleEn, paths.subtitleBilingual]
+    .map((filePath) => relativeArtifactPath(paths, filePath));
+  const metadataFiles = ASPECT_ORDER.flatMap((aspect) => SCENE_ORDER.map((scene) => (
+    relativeArtifactPath(paths, path.join(paths.intermediate, aspect, `${scene}.json`))
+  )));
+  return [...subtitleFiles, ...metadataFiles];
+}
+
+function buildValidationOcrTextFiles(paths: DemoPaths): string[] {
+  return ASPECT_ORDER.flatMap((aspect) => SCENE_ORDER.flatMap((scene) => (
+    ['start', 'action', 'end'].map((phase) => (
+      relativeArtifactPath(
+        paths,
+        path.join(paths.intermediate, 'ocr', aspect, `${scene}-${phase}.txt`),
+      )
+    ))
+  )));
+}
+
+type KeyframeOcrExtractor = (
+  options: ExtractKeyframeOcrOptions,
+) => Promise<KeyframeOcrResult>;
+
+function frameSignature(frames: readonly KeyframeOcrFrame[]): string {
+  return JSON.stringify(frames.map(({ aspect, scene, phase, relativePath, absolutePath }) => ({
+    aspect,
+    scene,
+    phase,
+    relativePath,
+    absolutePath,
+  })));
+}
+
+/** 初次验证和完整性复验共享同一次真实 OCR，避免重复编译和识别 42 张关键帧。 */
+export function createCachedKeyframeOcrRunner(
+  outputDir: string,
+  injectedExtractor?: KeyframeOcrExtractor,
+): KeyframeOcrRunner {
+  let cachedSignature: string | undefined;
+  let cachedResult: ReturnType<KeyframeOcrRunner> | undefined;
+
+  return async (frames) => {
+    const signature = frameSignature(frames);
+    if (cachedSignature && cachedSignature !== signature) {
+      throw new Error('自动 OCR 复验收到的关键帧集合与初次验证不一致');
+    }
+    cachedSignature ??= signature;
+    cachedResult ??= (async () => {
+      const extractor = injectedExtractor
+        ?? (await import('./ocr.ts')).extractKeyframeOcr;
+      const extraction = await extractor({
+        outputDir,
+        inputs: frames.map((frame) => ({
+          aspect: frame.aspect,
+          scene: frame.scene,
+          frame: frame.phase,
+          imagePath: frame.absolutePath,
+        })),
+      });
+      const entryByKey = new Map(extraction.manifest.entries.map((entry) => [
+        `${entry.aspect}/${entry.scene}/${entry.frame}`,
+        entry,
+      ]));
+      const evidence = await Promise.all(frames.map(async (frame) => {
+        const key = `${frame.aspect}/${frame.scene}/${frame.phase}`;
+        const entry = entryByKey.get(key);
+        if (!entry) throw new Error(`macOS Vision OCR 清单缺少关键帧：${key}`);
+        return {
+          relativePath: frame.relativePath,
+          text: await readFile(path.join(extraction.outputDir, entry.textFile), 'utf8'),
+        };
+      }));
+      return {
+        available: true as const,
+        engine: extraction.manifest.engine,
+        evidence,
+      };
+    })();
+    return cachedResult;
+  };
+}
+
+async function runValidate(context: CliCommandContext): Promise<void> {
+  const [consoleEntries, networkEntries] = await Promise.all([
+    readDiagnosticEntries(context.paths.consoleLog),
+    readDiagnosticEntries(context.paths.networkLog),
+  ]);
+  assertCompleteCaptureDiagnosticEntries(consoleEntries, networkEntries);
+
+  const [{ createDemoFixtures }, validation] = await Promise.all([
+    import('./fixtures.ts'),
+    import('./validate.ts'),
+  ]);
+  const logFiles = [context.paths.consoleLog, context.paths.networkLog]
+    .map((filePath) => relativeArtifactPath(context.paths, filePath));
+  const markdownFiles = [relativeArtifactPath(context.paths, context.paths.exportMarkdown)];
+  const sourceTextFiles = buildValidationSourceTextFiles(context.paths);
+  const ocrTextFiles = buildValidationOcrTextFiles(context.paths);
+  const runKeyframeOcr = createCachedKeyframeOcrRunner(
+    path.join(context.paths.intermediate, 'ocr'),
+  );
+  const commonOptions = {
+    artifactDir: context.paths.root,
+    logFiles,
+    markdownFiles,
+    sourceTextFiles,
+    ocrTextFiles,
+    runKeyframeOcr,
+    privacyObjects: [{ source: 'demo-fixtures', value: createDemoFixtures() }],
+  };
+
+  const initialValidation = await validation.validateDelivery(commonOptions);
+  await validation.writeManifest({
+    artifactDir: context.paths.root,
+    version: await readPackageVersion(context.cwd),
+    builtAt: new Date().toISOString(),
+    gitCommit: await readGitCommit(context.cwd),
+    validation: initialValidation,
+  });
+  await validation.validateDelivery({
+    ...commonOptions,
+    requireIntegrityFiles: true,
+  });
+}
+
+export function createDefaultCliDependencies(): CliDependencies {
+  return {
+    check: runCheck,
+    capture: runCapture,
+    subtitles: runSubtitles,
+    audio: runAudio,
+    compose: runCompose,
+    validate: runValidate,
+  };
+}
+
+export async function runCli(
+  argv: readonly string[],
+  options: RunCliOptions = {},
+): Promise<void> {
+  const args = parseCliArgs(argv);
+  const cwd = path.resolve(options.cwd ?? process.cwd());
+  const paths = createDemoPaths(cwd);
+  const dependencies = options.dependencies ?? createDefaultCliDependencies();
+
+  if (args.command === 'build') {
+    for (const command of BUILD_COMMAND_ORDER) {
+      await dependencies[command]({ cwd, paths, args: { command } });
+    }
+    return;
+  }
+
+  await dependencies[args.command]({ cwd, paths, args });
+}
+
+function isDirectExecution(): boolean {
+  const entry = process.argv[1];
+  return Boolean(entry) && import.meta.url === pathToFileURL(path.resolve(entry)).href;
+}
+
+if (isDirectExecution()) {
+  runCli(process.argv.slice(2)).catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/product-demo/compose.test.ts
+++ b/scripts/product-demo/compose.test.ts
@@ -1,0 +1,305 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import type { Browser, BrowserContextOptions } from 'playwright';
+
+import {
+  ASPECT_OUTPUT,
+  buildCompositionArgs,
+  buildCoverHtml,
+  composeDemoVideo,
+  renderCoverPng,
+  renderSubtitleOverlayPngs,
+} from './compose.ts';
+import {
+  DEMO_DURATION_SECONDS,
+  DEMO_FPS,
+  DEMO_TOTAL_FRAMES,
+  STORYBOARD,
+  VOICEOVER_CUES,
+} from './storyboard.ts';
+import type { CommandResult } from './ffmpeg.ts';
+
+const ok = (): CommandResult => ({ stdout: '', stderr: '', exitCode: 0 });
+
+function valueAfter(args: readonly string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function occurrenceCount(value: string, pattern: RegExp): number {
+  return [...value.matchAll(pattern)].length;
+}
+
+function compositionFixture(aspect: '16x9' | '9x16') {
+  return {
+    aspect,
+    sceneVideoPaths: STORYBOARD.map((scene) => `/tmp/work-review-demo/captures/${aspect}/${scene.id}.webm`),
+    subtitlePngPaths: VOICEOVER_CUES.map((cue, index) => (
+      `/tmp/work-review-demo/overlays/${aspect}/${String(index + 1).padStart(2, '0')}-${cue.id}.png`
+    )),
+    mixPath: '/tmp/work-review-demo/audio/mix.wav',
+    outputPath: `/tmp/work-review-demo/final/work-review-${aspect}.mp4`,
+    sourceStartOffsetsSeconds: STORYBOARD.map((_, index) => 1.25 + index * 0.1),
+  };
+}
+
+test('横屏合成逐段定长、拼接 85 秒，并在最终缩放后按时间窗叠加七条字幕', () => {
+  const fixture = compositionFixture('16x9');
+  const sourceDurationsSeconds = STORYBOARD.map((scene, index) => (
+    fixture.sourceStartOffsetsSeconds[index]!
+    + (scene.end - scene.start)
+    + (index === 2 ? -0.5 : 0.5)
+  ));
+  const args = buildCompositionArgs({ ...fixture, sourceDurationsSeconds });
+  const filter = valueAfter(args, '-filter_complex') ?? '';
+  const chains = filter.split(';');
+
+  STORYBOARD.forEach((scene, index) => {
+    const duration = (scene.end - scene.start).toFixed(3);
+    const chain = chains.find((value) => value.startsWith(`[${index}:v]`)) ?? '';
+    const start = fixture.sourceStartOffsetsSeconds[index]!.toFixed(3).replace('.', '\\.');
+    assert.match(chain, new RegExp(`trim=start=${start}:duration=${duration.replace('.', '\\.')}`));
+    assert.match(chain, /setpts=PTS-STARTPTS/);
+    assert.match(chain, new RegExp(`fps=${DEMO_FPS}`));
+    assert.match(chain, /crop=1920:1080:0:0/);
+    assert.match(chain, /scale=1920:1080:flags=lanczos/);
+    assert.match(chain, /pad=1920:1080:\(ow-iw\)\/2:\(oh-ih\)\/2/);
+    assert.match(chain, new RegExp(`trim=duration=${duration.replace('.', '\\.')}`));
+    if (index === 2) assert.match(chain, /tpad=stop_mode=clone/);
+    else assert.doesNotMatch(chain, /tpad=stop_mode=clone/);
+  });
+
+  assert.match(
+    filter,
+    /\[scene_0\]\[scene_1\]\[scene_2\]\[scene_3\]\[scene_4\]\[scene_5\]\[scene_6\]concat=n=7:v=1:a=0,trim=duration=85\.000,setpts=PTS-STARTPTS\[concatv\]/,
+  );
+  assert.equal(occurrenceCount(filter, /overlay=x=0:y=0:format=auto:enable='/g), VOICEOVER_CUES.length);
+  VOICEOVER_CUES.forEach((cue, index) => {
+    assert.match(
+      filter,
+      new RegExp(`\\[${STORYBOARD.length + index}:v\\]format=rgba,scale=1920:1080:flags=lanczos\\[subtitle_${index}\\]`),
+    );
+    assert.ok(filter.includes(`between(t,${cue.start.toFixed(3)},${cue.end.toFixed(3)})`));
+  });
+
+  assert.equal(occurrenceCount(args.join('\n'), /^-loop$/gm), VOICEOVER_CUES.length);
+  assert.equal(valueAfter(args, '-map'), '[finalv]');
+  const firstMap = args.indexOf('-map');
+  assert.equal(args[firstMap + 3], `${STORYBOARD.length + VOICEOVER_CUES.length}:a:0`);
+});
+
+test('未提供源时长时保守追加末帧并在目标时长再次裁切', () => {
+  const args = buildCompositionArgs(compositionFixture('16x9'));
+  const filter = valueAfter(args, '-filter_complex') ?? '';
+  const chains = filter.split(';');
+
+  STORYBOARD.forEach((scene, index) => {
+    const duration = (scene.end - scene.start).toFixed(3);
+    const chain = chains.find((value) => value.startsWith(`[${index}:v]`)) ?? '';
+    assert.match(chain, new RegExp(`tpad=stop_mode=clone:stop_duration=${duration.replace('.', '\\.')}`));
+    assert.match(chain, new RegExp(`trim=duration=${duration.replace('.', '\\.')}`));
+  });
+});
+
+test('源时长按内容起点扣除预卷后判断是否需要补帧', () => {
+  const fixture = compositionFixture('16x9');
+  const args = buildCompositionArgs({
+    ...fixture,
+    sourceDurationsSeconds: STORYBOARD.map((scene, index) => (
+      fixture.sourceStartOffsetsSeconds[index]! + (scene.end - scene.start) - (index === 0 ? 0.25 : -0.25)
+    )),
+  });
+  const chains = (valueAfter(args, '-filter_complex') ?? '').split(';');
+  assert.match(chains[0] ?? '', /tpad=stop_mode=clone:stop_duration=0\.250/);
+  assert.doesNotMatch(chains[1] ?? '', /tpad=stop_mode=clone/);
+});
+
+test('竖屏严格逐镜头使用 STORYBOARD 的独立 crop/scale，不做 concat 后全局裁切', () => {
+  const fixture = compositionFixture('9x16');
+  const args = buildCompositionArgs({
+    ...fixture,
+    sourceDurationsSeconds: STORYBOARD.map((scene) => scene.end - scene.start + 0.25),
+  });
+  const filter = valueAfter(args, '-filter_complex') ?? '';
+  const chains = filter.split(';');
+
+  STORYBOARD.forEach((scene, index) => {
+    const chain = chains.find((value) => value.startsWith(`[${index}:v]`)) ?? '';
+    assert.match(chain, new RegExp(`crop=${scene.composition['9x16'].crop.replaceAll(':', '\\:')}`));
+    assert.match(chain, new RegExp(`scale=${scene.composition['9x16'].scale.replaceAll(':', '\\:')}:flags=lanczos`));
+    assert.match(chain, /pad=1080:1920:\(ow-iw\)\/2:\(oh-ih\)\/2/);
+    assert.match(chain, /setsar=1/);
+  });
+
+  const portraitCrops = STORYBOARD.map((scene) => scene.composition['9x16'].crop);
+  assert.ok(new Set(portraitCrops).size > 1, '竖屏分镜必须具有不同构图');
+  assert.doesNotMatch(filter, /\[concatv\]crop=/);
+  assert.deepEqual(ASPECT_OUTPUT['9x16'], { width: 1080, height: 1920 });
+});
+
+test('最终 MP4 固定 H.264 CRF17 slow GOP60、AAC-LC 48k、faststart、Rec.709 和 2550 帧', () => {
+  const fixture = compositionFixture('16x9');
+  const args = buildCompositionArgs(fixture);
+
+  assert.equal(valueAfter(args, '-c:v'), 'libx264');
+  assert.equal(valueAfter(args, '-crf'), '17');
+  assert.equal(valueAfter(args, '-preset'), 'slow');
+  assert.equal(valueAfter(args, '-g'), '60');
+  assert.equal(valueAfter(args, '-keyint_min'), '60');
+  assert.equal(valueAfter(args, '-pix_fmt'), 'yuv420p');
+  assert.equal(valueAfter(args, '-r'), String(DEMO_FPS));
+  assert.equal(valueAfter(args, '-fps_mode'), 'cfr');
+  assert.equal(valueAfter(args, '-frames:v'), String(DEMO_TOTAL_FRAMES));
+  assert.equal(valueAfter(args, '-c:a'), 'aac');
+  assert.equal(valueAfter(args, '-profile:a'), 'aac_low');
+  assert.equal(valueAfter(args, '-ar'), '48000');
+  assert.equal(valueAfter(args, '-ac'), '2');
+  assert.equal(valueAfter(args, '-t'), DEMO_DURATION_SECONDS.toFixed(3));
+  assert.equal(valueAfter(args, '-movflags'), '+faststart');
+  assert.equal(valueAfter(args, '-color_primaries'), 'bt709');
+  assert.equal(valueAfter(args, '-color_trc'), 'bt709');
+  assert.equal(valueAfter(args, '-colorspace'), 'bt709');
+  const filter = valueAfter(args, '-filter_complex') ?? '';
+  assert.match(
+    filter,
+    /setparams=range=tv:color_primaries=bt709:color_trc=bt709:colorspace=bt709\[finalv\]$/u,
+  );
+  assert.equal(args.at(-1), fixture.outputPath);
+  assert.ok(args.includes(fixture.mixPath));
+  assert.ok(!args.includes('subtitles'));
+  assert.ok(!args.includes('ass'));
+  assert.ok(!args.includes('drawtext'));
+});
+
+test('透明双语字幕 PNG 通过可注入浏览器按目标画幅渲染', async () => {
+  const outputDir = await mkdtemp(join(tmpdir(), 'work-review-subtitle-overlays-'));
+  const calls = createBrowserSpy();
+  const cue = VOICEOVER_CUES[0]!;
+
+  const paths = await renderSubtitleOverlayPngs({
+    browser: calls.browser,
+    aspect: '9x16',
+    outputDir,
+    cues: [cue],
+  });
+
+  assert.deepEqual(calls.contextOptions[0]?.viewport, { width: 1080, height: 1920 });
+  assert.equal(paths.length, 1);
+  assert.equal(paths[0], join(outputDir, '9x16', 'subtitle-01-hook.png'));
+  assert.match(calls.html[0] ?? '', /width: 1080px/);
+  assert.match(calls.html[0] ?? '', /height: 1920px/);
+  assert.match(calls.html[0] ?? '', new RegExp(cue.zh));
+  assert.match(calls.html[0] ?? '', new RegExp(cue.en.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.deepEqual(calls.screenshots[0], {
+    path: paths[0],
+    omitBackground: true,
+    animations: 'disabled',
+    caret: 'hide',
+  });
+  assert.equal(calls.closed, 1);
+});
+
+test('封面用 public 图标数据和 HTML/CSS 独立构图，不依赖 FFmpeg 文字滤镜', async () => {
+  const outputDir = await mkdtemp(join(tmpdir(), 'work-review-cover-'));
+  const iconPath = join(outputDir, 'icon.png');
+  const outputPath = join(outputDir, 'cover-16x9.png');
+  await writeFile(iconPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  const calls = createBrowserSpy();
+
+  const html = buildCoverHtml('16x9', 'data:image/png;base64,iVBORw==');
+  assert.match(html, /Work-Review/);
+  assert.match(html, /回看今天，写下成果。/);
+  assert.match(html, /data:image\/png;base64,iVBORw==/);
+  assert.match(html, /width: 1920px/);
+  assert.match(html, /height: 1080px/);
+  assert.match(html, /width: calc\(100% - 32px\)/);
+  assert.match(html, /height: calc\(100% - 32px\)/);
+  assert.match(html, /border-radius: 42px/);
+  assert.doesNotMatch(html, /drawtext|subtitles|\.ass/u);
+
+  await renderCoverPng({
+    browser: calls.browser,
+    aspect: '16x9',
+    iconPath,
+    outputPath,
+  });
+
+  assert.match(calls.html[0] ?? '', /data:image\/png;base64,iVBORw==/);
+  assert.equal(calls.screenshots[0]?.path, outputPath);
+  assert.equal(calls.screenshots[0]?.omitBackground, true);
+  assert.equal(calls.closed, 1);
+});
+
+test('合成执行器可注入 runner，路径始终作为独立 argv 传递', async () => {
+  const outputDir = await mkdtemp(join(tmpdir(), 'work-review-compose-'));
+  const fixture = {
+    ...compositionFixture('16x9'),
+    outputPath: join(outputDir, 'final clip;$(touch nope).mp4'),
+  };
+  const calls: Array<{ binary: string; args: readonly string[] }> = [];
+
+  await composeDemoVideo({
+    ...fixture,
+    ffmpegPath: '/mock/bin/ffmpeg',
+    runner: async (binary, args) => {
+      calls.push({ binary, args });
+      return ok();
+    },
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.binary, '/mock/bin/ffmpeg');
+  assert.equal(calls[0]?.args.at(-1), fixture.outputPath);
+  assert.ok(calls[0]?.args.includes(fixture.outputPath));
+  assert.ok(!calls[0]?.args.some((value) => value.includes(`ffmpeg ${fixture.outputPath}`)));
+});
+
+function createBrowserSpy(): {
+  browser: Browser;
+  contextOptions: BrowserContextOptions[];
+  html: string[];
+  screenshots: Array<Record<string, unknown>>;
+  closed: number;
+} {
+  const state = {
+    contextOptions: [] as BrowserContextOptions[],
+    html: [] as string[],
+    screenshots: [] as Array<Record<string, unknown>>,
+    closed: 0,
+  };
+  const browser = {
+    async newContext(options: BrowserContextOptions) {
+      state.contextOptions.push(options);
+      return {
+        async newPage() {
+          return {
+            async setContent(html: string) {
+              state.html.push(html);
+            },
+            async evaluate() {
+              return undefined;
+            },
+            async screenshot(options: Record<string, unknown>) {
+              state.screenshots.push(options);
+              return Buffer.alloc(0);
+            },
+          };
+        },
+        async close() {
+          state.closed += 1;
+        },
+      };
+    },
+  } as unknown as Browser;
+
+  return {
+    browser,
+    contextOptions: state.contextOptions,
+    html: state.html,
+    screenshots: state.screenshots,
+    get closed() { return state.closed; },
+  };
+}

--- a/scripts/product-demo/compose.ts
+++ b/scripts/product-demo/compose.ts
@@ -1,0 +1,477 @@
+import { mkdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import type { Browser, BrowserContextOptions, Page } from 'playwright';
+
+import {
+  DEMO_DURATION_SECONDS,
+  DEMO_FPS,
+  DEMO_TOTAL_FRAMES,
+  STORYBOARD,
+  VOICEOVER_CUES,
+} from './storyboard.ts';
+import { buildSubtitleOverlayHtml } from './subtitles.ts';
+import {
+  discoverMediaBinaries,
+  runCommand,
+  type CommandResult,
+  type CommandRunner,
+} from './ffmpeg.ts';
+import type {
+  DemoAspect,
+  StoryboardCue,
+  StoryboardScene,
+} from './types.ts';
+
+export const ASPECT_OUTPUT = {
+  '16x9': { width: 1920, height: 1080 },
+  '9x16': { width: 1080, height: 1920 },
+} as const satisfies Record<DemoAspect, { width: number; height: number }>;
+
+const COVER_COPY = '回看今天，写下成果。';
+const SYSTEM_FONT_STACK = [
+  '-apple-system',
+  'BlinkMacSystemFont',
+  '"PingFang SC"',
+  '"Microsoft YaHei"',
+  '"Noto Sans CJK SC"',
+  'sans-serif',
+].join(', ');
+
+export interface BuildCompositionOptions {
+  aspect: DemoAspect;
+  sceneVideoPaths: readonly string[];
+  subtitlePngPaths: readonly string[];
+  mixPath: string;
+  outputPath: string;
+  sourceDurationsSeconds?: readonly number[];
+  sourceStartOffsetsSeconds?: readonly number[];
+  scenes?: readonly StoryboardScene[];
+  cues?: readonly StoryboardCue[];
+}
+
+export interface ComposeDemoVideoOptions extends BuildCompositionOptions {
+  ffmpegPath?: string;
+  runner?: CommandRunner;
+}
+
+export interface RenderSubtitleOverlayOptions {
+  browser: Browser;
+  aspect: DemoAspect;
+  outputDir: string;
+  cues?: readonly StoryboardCue[];
+}
+
+export interface RenderCoverOptions {
+  browser: Browser;
+  aspect: DemoAspect;
+  outputPath: string;
+  iconPath?: string;
+}
+
+function assertNonEmpty(value: string, label: string): void {
+  if (!value.trim()) throw new Error(`${label}不能为空`);
+}
+
+function assertFinitePositive(value: number, label: string): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${label}必须是正有限数`);
+  }
+}
+
+function fixedSeconds(value: number): string {
+  return value.toFixed(3);
+}
+
+function parseCompositionValue(value: string, expectedParts: number, label: string): number[] {
+  const parts = value.split(':').map(Number);
+  if (parts.length !== expectedParts || parts.some((part) => !Number.isFinite(part) || part < 0)) {
+    throw new Error(`${label}格式无效：${value}`);
+  }
+  return parts;
+}
+
+function validateCompositionOptions(
+  options: BuildCompositionOptions,
+  scenes: readonly StoryboardScene[],
+  cues: readonly StoryboardCue[],
+): void {
+  if (scenes.length !== 7) throw new Error('产品演示合成必须包含七个分镜');
+  if (options.sceneVideoPaths.length !== scenes.length) {
+    throw new Error(`分镜视频数量必须为 ${scenes.length}`);
+  }
+  if (options.subtitlePngPaths.length !== cues.length) {
+    throw new Error(`字幕 PNG 数量必须为 ${cues.length}`);
+  }
+  if (
+    options.sourceDurationsSeconds
+    && options.sourceDurationsSeconds.length !== scenes.length
+  ) {
+    throw new Error(`源视频时长数量必须为 ${scenes.length}`);
+  }
+  if (
+    options.sourceStartOffsetsSeconds
+    && options.sourceStartOffsetsSeconds.length !== scenes.length
+  ) {
+    throw new Error(`源视频内容起点数量必须为 ${scenes.length}`);
+  }
+
+  options.sceneVideoPaths.forEach((value, index) => assertNonEmpty(value, `分镜视频 ${index + 1}`));
+  options.subtitlePngPaths.forEach((value, index) => assertNonEmpty(value, `字幕 PNG ${index + 1}`));
+  options.sourceDurationsSeconds?.forEach((value, index) => (
+    assertFinitePositive(value, `源视频 ${index + 1} 时长`)
+  ));
+  options.sourceStartOffsetsSeconds?.forEach((value, index) => {
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error(`源视频 ${index + 1} 内容起点必须是非负有限数`);
+    }
+  });
+  assertNonEmpty(options.mixPath, '最终混音路径');
+  assertNonEmpty(options.outputPath, '输出视频路径');
+}
+
+function buildSceneFilter(
+  scene: StoryboardScene,
+  aspect: DemoAspect,
+  inputIndex: number,
+  sourceDurationSeconds?: number,
+  sourceStartOffsetSeconds = 0,
+): string {
+  const targetDuration = scene.end - scene.start;
+  assertFinitePositive(targetDuration, `分镜 ${scene.id} 目标时长`);
+  const composition = scene.composition[aspect];
+  const [cropWidth, cropHeight, cropX, cropY] = parseCompositionValue(
+    composition.crop,
+    4,
+    `分镜 ${scene.id} crop`,
+  );
+  const [scaleWidth, scaleHeight] = parseCompositionValue(
+    composition.scale,
+    2,
+    `分镜 ${scene.id} scale`,
+  );
+  const output = ASPECT_OUTPUT[aspect];
+  if (scaleWidth !== output.width || scaleHeight !== output.height) {
+    throw new Error(
+      `分镜 ${scene.id} 的 ${aspect} scale 必须统一为 ${output.width}:${output.height}`,
+    );
+  }
+
+  const filters = [
+    `trim=start=${fixedSeconds(sourceStartOffsetSeconds)}:duration=${fixedSeconds(targetDuration)}`,
+    'setpts=PTS-STARTPTS',
+    `fps=${DEMO_FPS}`,
+  ];
+
+  if (aspect === '9x16') {
+    // 竖屏录制已是独立响应式页面；先放大到 1920 宽参考画布，
+    // 再使用 STORYBOARD 为每个镜头定义的不同焦点坐标进行重构。
+    filters.push('scale=1920:-2:flags=lanczos');
+  }
+
+  filters.push(
+    `crop=${cropWidth}:${cropHeight}:${cropX}:${cropY}`,
+    `scale=${scaleWidth}:${scaleHeight}:flags=lanczos`,
+    `pad=${output.width}:${output.height}:(ow-iw)/2:(oh-ih)/2:color=black`,
+    'setsar=1',
+  );
+
+  const availableDuration = sourceDurationSeconds === undefined
+    ? undefined
+    : Math.max(0, sourceDurationSeconds - sourceStartOffsetSeconds);
+  if (availableDuration === undefined || availableDuration < targetDuration) {
+    const paddingDuration = sourceDurationSeconds === undefined
+      ? targetDuration
+      : targetDuration - availableDuration!;
+    filters.push(`tpad=stop_mode=clone:stop_duration=${fixedSeconds(paddingDuration)}`);
+  }
+
+  filters.push(
+    `trim=duration=${fixedSeconds(targetDuration)}`,
+    'setpts=PTS-STARTPTS',
+    'format=yuv420p',
+  );
+
+  return `[${inputIndex}:v]${filters.join(',')}[scene_${inputIndex}]`;
+}
+
+function buildSubtitleFilters(
+  cues: readonly StoryboardCue[],
+  subtitleInputOffset: number,
+  output: { width: number; height: number },
+): { filters: string[]; finalLabel: string } {
+  if (cues.length === 0) return { filters: [], finalLabel: 'concatv' };
+
+  const filters: string[] = [];
+  let baseLabel = 'concatv';
+  cues.forEach((cue, index) => {
+    const subtitleLabel = `subtitle_${index}`;
+    const outputLabel = index === cues.length - 1 ? 'subtitle_done' : `overlay_${index}`;
+    filters.push(
+      `[${subtitleInputOffset + index}:v]format=rgba,scale=${output.width}:${output.height}:flags=lanczos[${subtitleLabel}]`,
+    );
+    filters.push(
+      `[${baseLabel}][${subtitleLabel}]overlay=x=0:y=0:format=auto:enable='between(t,${fixedSeconds(cue.start)},${fixedSeconds(cue.end)})'[${outputLabel}]`,
+    );
+    baseLabel = outputLabel;
+  });
+
+  return { filters, finalLabel: 'subtitle_done' };
+}
+
+/** 构建七段视频、透明字幕和最终混音的确定性 FFmpeg 参数。 */
+export function buildCompositionArgs(options: BuildCompositionOptions): string[] {
+  const scenes = options.scenes ?? STORYBOARD;
+  const cues = options.cues ?? VOICEOVER_CUES;
+  validateCompositionOptions(options, scenes, cues);
+  const output = ASPECT_OUTPUT[options.aspect];
+  const args: string[] = ['-y', '-hide_banner'];
+
+  for (const videoPath of options.sceneVideoPaths) {
+    args.push('-i', videoPath);
+  }
+  for (const subtitlePath of options.subtitlePngPaths) {
+    args.push('-loop', '1', '-framerate', String(DEMO_FPS), '-i', subtitlePath);
+  }
+  const audioInputIndex = scenes.length + cues.length;
+  args.push('-i', options.mixPath);
+
+  const filters = scenes.map((scene, index) => buildSceneFilter(
+    scene,
+    options.aspect,
+    index,
+    options.sourceDurationsSeconds?.[index],
+    options.sourceStartOffsetsSeconds?.[index],
+  ));
+  filters.push(
+    `${scenes.map((_, index) => `[scene_${index}]`).join('')}concat=n=${scenes.length}:v=1:a=0,trim=duration=${fixedSeconds(DEMO_DURATION_SECONDS)},setpts=PTS-STARTPTS[concatv]`,
+  );
+  const subtitleFilters = buildSubtitleFilters(cues, scenes.length, output);
+  filters.push(...subtitleFilters.filters);
+  filters.push(
+    `[${subtitleFilters.finalLabel}]setparams=range=tv:color_primaries=bt709:color_trc=bt709:colorspace=bt709[finalv]`,
+  );
+
+  args.push(
+    '-filter_complex', filters.join(';'),
+    '-map', '[finalv]',
+    '-map', `${audioInputIndex}:a:0`,
+    '-c:v', 'libx264',
+    '-crf', '17',
+    '-preset', 'slow',
+    '-g', '60',
+    '-keyint_min', '60',
+    '-sc_threshold', '0',
+    '-pix_fmt', 'yuv420p',
+    '-r', String(DEMO_FPS),
+    '-fps_mode', 'cfr',
+    '-frames:v', String(DEMO_TOTAL_FRAMES),
+    '-c:a', 'aac',
+    '-profile:a', 'aac_low',
+    '-b:a', '192k',
+    '-ar', '48000',
+    '-ac', '2',
+    '-t', fixedSeconds(DEMO_DURATION_SECONDS),
+    '-movflags', '+faststart',
+    '-color_primaries', 'bt709',
+    '-color_trc', 'bt709',
+    '-colorspace', 'bt709',
+    options.outputPath,
+  );
+
+  return args;
+}
+
+/** 执行最终视频合成；runner 可在测试或编排层注入。 */
+export async function composeDemoVideo(
+  options: ComposeDemoVideoOptions,
+): Promise<CommandResult> {
+  await mkdir(dirname(options.outputPath), { recursive: true });
+  const runner = options.runner ?? runCommand;
+  const ffmpegPath = options.ffmpegPath
+    ?? (await discoverMediaBinaries({ runner })).ffmpeg;
+  return runner(ffmpegPath, buildCompositionArgs(options), {
+    maxCaptureBytes: 4 * 1024 * 1024,
+  });
+}
+
+function createVisualContextOptions(aspect: DemoAspect): BrowserContextOptions {
+  return {
+    viewport: { ...ASPECT_OUTPUT[aspect] },
+    deviceScaleFactor: 1,
+    locale: 'zh-CN',
+    timezoneId: 'Asia/Shanghai',
+    reducedMotion: 'reduce',
+    colorScheme: 'light',
+  };
+}
+
+async function waitForFonts(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    await document.fonts?.ready;
+  });
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[character] ?? character);
+}
+
+/** 用 Playwright 把双语字幕 HTML/CSS 渲染为带 alpha 的整帧 PNG。 */
+export async function renderSubtitleOverlayPngs(
+  options: RenderSubtitleOverlayOptions,
+): Promise<string[]> {
+  const cues = options.cues ?? VOICEOVER_CUES;
+  const aspectDir = join(options.outputDir, options.aspect);
+  await mkdir(aspectDir, { recursive: true });
+  const context = await options.browser.newContext(createVisualContextOptions(options.aspect));
+
+  try {
+    const page = await context.newPage();
+    const paths: string[] = [];
+    for (const [index, cue] of cues.entries()) {
+      const outputPath = join(
+        aspectDir,
+        `subtitle-${String(index + 1).padStart(2, '0')}-${cue.id}.png`,
+      );
+      await page.setContent(buildSubtitleOverlayHtml(cue, options.aspect), { waitUntil: 'load' });
+      await waitForFonts(page);
+      await page.screenshot({
+        path: outputPath,
+        omitBackground: true,
+        animations: 'disabled',
+        caret: 'hide',
+      });
+      paths.push(outputPath);
+    }
+    return paths;
+  } finally {
+    await context.close();
+  }
+}
+
+/** 构建横竖屏分别排版的产品封面 HTML。 */
+export function buildCoverHtml(aspect: DemoAspect, iconDataUrl: string): string {
+  assertNonEmpty(iconDataUrl, '封面图标数据');
+  const output = ASPECT_OUTPUT[aspect];
+  const portrait = aspect === '9x16';
+  const iconSize = portrait ? 300 : 240;
+  const titleSize = portrait ? 104 : 92;
+  const taglineSize = portrait ? 48 : 42;
+  const padding = portrait ? 96 : 120;
+
+  return `<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    * { box-sizing: border-box; }
+    html, body {
+      width: ${output.width}px;
+      height: ${output.height}px;
+      margin: 0;
+      overflow: hidden;
+      background: transparent;
+    }
+    body {
+      display: grid;
+      place-items: center;
+      color: #f8fafc;
+      font-family: ${SYSTEM_FONT_STACK};
+      -webkit-font-smoothing: antialiased;
+    }
+    .cover {
+      position: relative;
+      width: calc(100% - 32px);
+      height: calc(100% - 32px);
+      display: flex;
+      flex-direction: ${portrait ? 'column' : 'row'};
+      align-items: center;
+      justify-content: center;
+      gap: ${portrait ? 74 : 64}px;
+      padding: ${padding}px;
+      border-radius: 42px;
+      background:
+        radial-gradient(circle at 20% 18%, rgb(56 189 248 / 32%), transparent 38%),
+        radial-gradient(circle at 82% 78%, rgb(129 140 248 / 30%), transparent 42%),
+        linear-gradient(145deg, #07111f 0%, #101a2e 52%, #07111f 100%);
+    }
+    .cover::after {
+      content: '';
+      position: absolute;
+      inset: 28px;
+      border: 1px solid rgb(255 255 255 / 12%);
+      border-radius: 34px;
+      pointer-events: none;
+    }
+    .icon-shell {
+      flex: 0 0 auto;
+      width: ${iconSize}px;
+      height: ${iconSize}px;
+      padding: ${portrait ? 30 : 24}px;
+      border: 1px solid rgb(255 255 255 / 20%);
+      border-radius: ${portrait ? 72 : 58}px;
+      background: rgb(255 255 255 / 10%);
+      box-shadow: 0 34px 90px rgb(0 0 0 / 38%);
+      backdrop-filter: blur(18px);
+    }
+    .icon-shell img { width: 100%; height: 100%; object-fit: contain; }
+    .copy { text-align: ${portrait ? 'center' : 'left'}; }
+    h1 {
+      margin: 0;
+      font-size: ${titleSize}px;
+      font-weight: 760;
+      line-height: 1.04;
+      letter-spacing: -0.035em;
+    }
+    p {
+      margin: ${portrait ? 34 : 28}px 0 0;
+      color: rgb(226 232 240 / 88%);
+      font-size: ${taglineSize}px;
+      font-weight: 520;
+      line-height: 1.35;
+      letter-spacing: 0.02em;
+    }
+  </style>
+</head>
+<body>
+  <main class="cover" aria-label="Work-Review 产品封面">
+    <div class="icon-shell"><img src="${escapeHtml(iconDataUrl)}" alt="Work-Review"></div>
+    <div class="copy">
+      <h1>Work-Review</h1>
+      <p>${COVER_COPY}</p>
+    </div>
+  </main>
+</body>
+</html>
+`;
+}
+
+/** 使用 public/icon.png 和 Playwright HTML/CSS 生成封面 PNG。 */
+export async function renderCoverPng(options: RenderCoverOptions): Promise<string> {
+  const iconPath = options.iconPath ?? join(process.cwd(), 'public', 'icon.png');
+  const iconBytes = await readFile(iconPath);
+  const iconDataUrl = `data:image/png;base64,${iconBytes.toString('base64')}`;
+  await mkdir(dirname(options.outputPath), { recursive: true });
+  const context = await options.browser.newContext(createVisualContextOptions(options.aspect));
+
+  try {
+    const page = await context.newPage();
+    await page.setContent(buildCoverHtml(options.aspect, iconDataUrl), { waitUntil: 'load' });
+    await waitForFonts(page);
+    await page.screenshot({
+      path: options.outputPath,
+      omitBackground: true,
+      animations: 'disabled',
+      caret: 'hide',
+    });
+    return options.outputPath;
+  } finally {
+    await context.close();
+  }
+}

--- a/scripts/product-demo/ffmpeg.test.ts
+++ b/scripts/product-demo/ffmpeg.test.ts
@@ -1,0 +1,477 @@
+import assert from 'node:assert/strict';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  buildExecutableCandidates,
+  buildFinalVideoArgs,
+  buildLoudnormAnalysisArgs,
+  buildLoudnormRenderArgs,
+  buildProbeArgs,
+  discoverMediaBinaries,
+  parseLoudnormMeasurement,
+  parseMediaProbe,
+  probeMedia,
+  runCommand,
+  type CommandResult,
+} from './ffmpeg.ts';
+import {
+  AUDIO_SAMPLE_RATE,
+  DEFAULT_SOUND_EFFECTS,
+  buildAudioMixArgs,
+  buildBackgroundMusicArgs,
+  buildSayCommand,
+  buildSayVoiceListCommand,
+  buildSoundEffectsArgs,
+  buildVoiceover,
+  buildVoiceoverConversionArgs,
+  buildVoiceoverMixArgs,
+  hasTingtingVoice,
+  mixDemoAudio,
+} from './audio.ts';
+
+const ok = (stdout = '', stderr = ''): CommandResult => ({
+  stdout,
+  stderr,
+  exitCode: 0,
+});
+
+function valueAfter(args: readonly string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+test('最终视频参数固定为 30fps、2550 帧、H.264/AAC/yuv420p 和 faststart', () => {
+  const videoPath = '/tmp/work-review-demo/input clip;$(touch nope).webm';
+  const audioPath = '/tmp/work-review-demo/mix audio.wav';
+  const outputPath = '/tmp/work-review-demo/final landscape.mp4';
+  const args = buildFinalVideoArgs({
+    videoPath,
+    audioPath,
+    outputPath,
+    width: 1920,
+    height: 1080,
+  });
+
+  assert.equal(valueAfter(args, '-r'), '30');
+  assert.equal(valueAfter(args, '-frames:v'), '2550');
+  assert.equal(valueAfter(args, '-c:v'), 'libx264');
+  assert.equal(valueAfter(args, '-pix_fmt'), 'yuv420p');
+  assert.equal(valueAfter(args, '-c:a'), 'aac');
+  assert.equal(valueAfter(args, '-ar'), '48000');
+  assert.equal(valueAfter(args, '-ac'), '2');
+  assert.equal(valueAfter(args, '-t'), '85.000');
+  assert.equal(valueAfter(args, '-movflags'), '+faststart');
+  assert.match(valueAfter(args, '-vf') ?? '', /fps=30/);
+  assert.match(valueAfter(args, '-vf') ?? '', /scale=1920:1080/);
+  assert.ok(args.includes(videoPath));
+  assert.ok(args.includes(audioPath));
+  assert.equal(args.at(-1), outputPath);
+  assert.ok(!args.some((arg) => arg.includes(`ffmpeg ${videoPath}`)));
+});
+
+test('响度规范化参数严格执行固定两遍 loudnorm', () => {
+  const analysis = buildLoudnormAnalysisArgs('/tmp/work-review-demo/unmastered.wav');
+  const measurement = {
+    inputI: -22.4,
+    inputTp: -3.2,
+    inputLra: 4.1,
+    inputThresh: -32.7,
+    targetOffset: 0.3,
+  };
+  const render = buildLoudnormRenderArgs(
+    '/tmp/work-review-demo/unmastered.wav',
+    '/tmp/work-review-demo/mix.wav',
+    measurement,
+  );
+
+  assert.match(valueAfter(analysis, '-af') ?? '', /loudnorm=I=-14:TP=-1:LRA=7/);
+  assert.match(valueAfter(analysis, '-af') ?? '', /print_format=json/);
+  assert.equal(valueAfter(analysis, '-f'), 'null');
+
+  const renderFilter = valueAfter(render, '-af') ?? '';
+  assert.match(renderFilter, /^loudnorm=I=-14:TP=-1:LRA=7:/);
+  assert.match(renderFilter, /measured_I=-22\.4/);
+  assert.match(renderFilter, /measured_TP=-3\.2/);
+  assert.match(renderFilter, /measured_LRA=4\.1/);
+  assert.match(renderFilter, /measured_thresh=-32\.7/);
+  assert.match(renderFilter, /offset=0\.3/);
+  assert.match(renderFilter, /linear=true/);
+  assert.equal(valueAfter(render, '-ar'), '48000');
+  assert.equal(valueAfter(render, '-ac'), '2');
+  assert.equal(valueAfter(render, '-t'), '85.000');
+});
+
+test('解析 loudnorm 首遍 JSON，拒绝缺失或非数值字段', () => {
+  const stderr = `frame=123\n[Parsed_loudnorm_0]\n{
+    "input_i" : "-22.40",
+    "input_tp" : "-3.20",
+    "input_lra" : "4.10",
+    "input_thresh" : "-32.70",
+    "target_offset" : "0.30"
+  }\n`;
+
+  assert.deepEqual(parseLoudnormMeasurement(stderr), {
+    inputI: -22.4,
+    inputTp: -3.2,
+    inputLra: 4.1,
+    inputThresh: -32.7,
+    targetOffset: 0.3,
+  });
+  assert.throws(() => parseLoudnormMeasurement('{"input_i":"-22"}'), /loudnorm.*字段/);
+});
+
+test('ffprobe 参数请求 JSON、流信息、格式信息和精确帧计数', () => {
+  const mediaPath = '/tmp/work-review-demo/video with spaces.mp4';
+  const args = buildProbeArgs(mediaPath);
+
+  assert.deepEqual(args.slice(0, 2), ['-v', 'error']);
+  assert.ok(args.includes('-show_streams'));
+  assert.ok(args.includes('-show_format'));
+  assert.ok(args.includes('-count_frames'));
+  assert.equal(valueAfter(args, '-print_format'), 'json');
+  assert.equal(args.at(-1), mediaPath);
+});
+
+test('媒体探测结果解析时长、帧率、帧数、编解码器和画面规格', () => {
+  const result = parseMediaProbe(JSON.stringify({
+    format: { duration: '85.000000', format_name: 'mov,mp4,m4a,3gp,3g2,mj2' },
+    streams: [
+      {
+        index: 0,
+        codec_type: 'video',
+        codec_name: 'h264',
+        pix_fmt: 'yuv420p',
+        width: 1920,
+        height: 1080,
+        r_frame_rate: '30/1',
+        avg_frame_rate: '30/1',
+        nb_frames: '2550',
+        nb_read_frames: '2550',
+        duration: '85.000000',
+      },
+      {
+        index: 1,
+        codec_type: 'audio',
+        codec_name: 'aac',
+        sample_rate: '48000',
+        channels: 2,
+        channel_layout: 'stereo',
+        duration: '85.000000',
+      },
+    ],
+  }));
+
+  assert.equal(result.durationSeconds, 85);
+  assert.equal(result.formatName, 'mov,mp4,m4a,3gp,3g2,mj2');
+  assert.deepEqual(result.video, {
+    codec: 'h264',
+    pixelFormat: 'yuv420p',
+    width: 1920,
+    height: 1080,
+    frameRate: 30,
+    averageFrameRate: 30,
+    frameCount: 2550,
+    durationSeconds: 85,
+  });
+  assert.deepEqual(result.audio, {
+    codec: 'aac',
+    sampleRate: 48000,
+    channels: 2,
+    channelLayout: 'stereo',
+    durationSeconds: 85,
+  });
+});
+
+test('媒体探测支持读取帧数回退并拒绝无效 JSON 或无媒体流', () => {
+  const fallback = parseMediaProbe(JSON.stringify({
+    format: { duration: '1.5' },
+    streams: [{
+      codec_type: 'video',
+      codec_name: 'h264',
+      width: 1080,
+      height: 1920,
+      avg_frame_rate: '30000/1001',
+      nb_frames: 'N/A',
+      nb_read_frames: '45',
+    }],
+  }));
+
+  assert.equal(fallback.video?.frameCount, 45);
+  assert.ok(Math.abs((fallback.video?.averageFrameRate ?? 0) - 29.97002997) < 1e-6);
+  assert.throws(() => parseMediaProbe('not-json'), /ffprobe JSON/);
+  assert.throws(() => parseMediaProbe('null'), /ffprobe JSON.*对象/);
+  const unknownDuration = parseMediaProbe(JSON.stringify({
+    format: {},
+    streams: [{ codec_type: 'audio', codec_name: 'aac' }],
+  }));
+  assert.equal(unknownDuration.durationSeconds, null);
+
+  assert.throws(
+    () => parseMediaProbe(JSON.stringify({ format: { duration: '85' }, streams: [] })),
+    /未发现音视频流/,
+  );
+});
+
+test('probeMedia 通过参数数组调用指定 ffprobe 并解析 stdout', async () => {
+  const calls: Array<{ binary: string; args: readonly string[] }> = [];
+  const result = await probeMedia('/tmp/work-review-demo/sample.mp4', {
+    ffprobePath: '/opt/tools/ffprobe',
+    runner: async (binary, args) => {
+      calls.push({ binary, args });
+      return ok(JSON.stringify({
+        format: { duration: '85.0' },
+        streams: [{ codec_type: 'audio', codec_name: 'aac', sample_rate: '48000', channels: 2 }],
+      }));
+    },
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.binary, '/opt/tools/ffprobe');
+  assert.equal(calls[0]?.args.at(-1), '/tmp/work-review-demo/sample.mp4');
+  assert.equal(result.audio?.codec, 'aac');
+});
+
+test('可执行文件候选优先环境覆盖，并从 PATH 与 macOS 常见目录发现工具', async () => {
+  const env = {
+    PATH: '/custom/bin:/usr/bin',
+    FFMPEG_PATH: '/private/tools/ffmpeg custom',
+    FFPROBE_PATH: '/private/tools/ffprobe custom',
+  };
+  const ffmpegCandidates = buildExecutableCandidates('ffmpeg', { env, platform: 'darwin' });
+
+  assert.equal(ffmpegCandidates[0], '/private/tools/ffmpeg custom');
+  assert.ok(ffmpegCandidates.includes('/custom/bin/ffmpeg'));
+  assert.ok(ffmpegCandidates.includes('/opt/homebrew/bin/ffmpeg'));
+
+  const executable = new Set(['/private/tools/ffmpeg custom', '/custom/bin/ffprobe']);
+  const verified: string[] = [];
+  const binaries = await discoverMediaBinaries({
+    env,
+    platform: 'darwin',
+    isExecutable: async (candidate) => executable.has(candidate),
+    runner: async (binary, args) => {
+      verified.push(`${binary}\0${args.join('\0')}`);
+      return ok(`${binary} version 8.0`);
+    },
+  });
+
+  assert.deepEqual(binaries, {
+    ffmpeg: '/private/tools/ffmpeg custom',
+    ffprobe: '/custom/bin/ffprobe',
+  });
+  assert.deepEqual(verified, [
+    '/private/tools/ffmpeg custom\0-version',
+    '/custom/bin/ffprobe\0-version',
+  ]);
+});
+
+test('找不到 ffmpeg 或 ffprobe 时给出明确错误', async () => {
+  await assert.rejects(
+    discoverMediaBinaries({
+      env: { PATH: '/missing' },
+      platform: 'darwin',
+      isExecutable: async () => false,
+      runner: async () => ok(),
+    }),
+    /未找到可用的 ffmpeg/,
+  );
+});
+
+test('runCommand 不启用 shell，危险字符和空格保持单个参数', async () => {
+  const dangerous = '/tmp/work-review-demo/clip; echo SHOULD_NOT_RUN $(uname).webm';
+  const result = await runCommand(process.execPath, [
+    '-e',
+    'process.stdout.write(JSON.stringify(process.argv.slice(1)))',
+    dangerous,
+    '第二个参数',
+  ]);
+
+  assert.deepEqual(JSON.parse(result.stdout), [dangerous, '第二个参数']);
+});
+
+test('runCommand 失败信息包含退出码和截断后的 stderr', async () => {
+  await assert.rejects(
+    runCommand(
+      process.execPath,
+      ['-e', 'process.stderr.write("PREFIX-" + "x".repeat(400) + "-FINAL ERROR"); process.exit(7)'],
+      { maxCaptureBytes: 64 },
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /退出码 7/);
+      assert.match(error.message, /已截断/);
+      assert.match(error.message, /FINAL ERROR/);
+      assert.doesNotMatch(error.message, /PREFIX/);
+      assert.ok(error.message.length < 300);
+      return true;
+    },
+  );
+});
+
+test('Tingting 旁白命令保持文本和路径为独立参数，不经过 shell', () => {
+  const list = buildSayVoiceListCommand();
+  assert.deepEqual(list, { binary: '/usr/bin/say', args: ['-v', '?'] });
+  assert.equal(hasTingtingVoice('Tingting            zh_CN    # 您好'), true);
+  assert.equal(hasTingtingVoice('Meijia              zh_TW    # 您好'), false);
+
+  const text = '日报完成；$(touch /tmp/nope) && echo 不执行';
+  const outputPath = '/tmp/work-review-demo/voice cue 01.aiff';
+  const command = buildSayCommand(text, outputPath);
+
+  assert.equal(command.binary, '/usr/bin/say');
+  assert.deepEqual(command.args, ['-v', 'Tingting', '-o', outputPath, text]);
+});
+
+test('旁白 AIFF 转 WAV 固定 48kHz 双声道，时间线混合固定 85 秒', () => {
+  const conversion = buildVoiceoverConversionArgs('cue.aiff', 'cue.wav');
+  assert.equal(valueAfter(conversion, '-ar'), String(AUDIO_SAMPLE_RATE));
+  assert.equal(valueAfter(conversion, '-ac'), '2');
+  assert.equal(valueAfter(conversion, '-c:a'), 'pcm_s24le');
+  assert.equal(conversion.at(-1), 'cue.wav');
+
+  const mix = buildVoiceoverMixArgs([
+    { path: 'first.wav', startSeconds: 0.35 },
+    { path: 'second.wav', startSeconds: 7.35 },
+  ], 'voiceover.wav');
+  const filter = valueAfter(mix, '-filter_complex') ?? '';
+  assert.match(filter, /adelay=350\|350/);
+  assert.match(filter, /adelay=7350\|7350/);
+  assert.match(filter, /amix=inputs=2:normalize=0/);
+  assert.match(filter, /atrim=0:85/);
+  assert.match(filter, /apad=whole_dur=85/);
+  assert.equal(valueAfter(mix, '-ar'), '48000');
+  assert.equal(valueAfter(mix, '-ac'), '2');
+});
+
+test('buildVoiceover 可注入命令执行器，单句超时会报告实际时长而不强制加速', async () => {
+  const outputDir = await mkdtemp(join(tmpdir(), 'work-review-voiceover-'));
+  const calls: Array<{ binary: string; args: readonly string[] }> = [];
+
+  await assert.rejects(
+    buildVoiceover(
+      [{ id: 'too-long', start: 78.35, end: 84.65, zh: '最后一句', en: 'Last line' }],
+      {
+        outputDir,
+        ffmpegPath: '/mock/ffmpeg',
+        runner: async (binary, args) => {
+          calls.push({ binary, args });
+          if (binary === '/usr/bin/say' && args[1] === '?') {
+            return ok('Tingting            zh_CN    # 您好');
+          }
+          return ok();
+        },
+        probe: async () => ({
+          durationSeconds: 5.2,
+          formatName: 'wav',
+          video: null,
+          audio: {
+            codec: 'pcm_s24le',
+            sampleRate: 48000,
+            channels: 2,
+            channelLayout: 'stereo',
+            durationSeconds: 5.2,
+          },
+        }),
+      },
+    ),
+    /too-long.*实际 5\.200 秒.*83\.000 秒前/,
+  );
+
+  assert.equal(calls[0]?.binary, '/usr/bin/say');
+  assert.deepEqual(calls[0]?.args, ['-v', '?']);
+  assert.ok(calls.some(({ binary, args }) => binary === '/usr/bin/say' && args[0] === '-v'
+    && args[1] === 'Tingting' && args.includes('最后一句')));
+  assert.ok(calls.some(({ binary }) => binary === '/mock/ffmpeg'));
+});
+
+test('程序化背景音乐使用正弦波、低通、淡入淡出并自然收束到 85 秒', () => {
+  const args = buildBackgroundMusicArgs('/tmp/work-review-demo/background.wav');
+  const joined = args.join(' ');
+
+  assert.match(joined, /sine=frequency=/);
+  assert.match(joined, /sample_rate=48000/);
+  assert.match(joined, /duration=85/);
+  const filter = valueAfter(args, '-filter_complex') ?? '';
+  assert.match(filter, /amix=inputs=3:normalize=0:duration=longest,lowpass=/);
+  assert.match(filter, /lowpass=/);
+  assert.match(filter, /afade=t=in/);
+  assert.match(valueAfter(args, '-filter_complex') ?? '', /afade=t=out:st=80:d=5/);
+  assert.match(valueAfter(args, '-filter_complex') ?? '', /atrim=0:85/);
+  assert.equal(valueAfter(args, '-ar'), '48000');
+  assert.equal(valueAfter(args, '-ac'), '2');
+});
+
+test('点击、切换、完成和片尾音效由短包络正弦波程序化生成', () => {
+  const args = buildSoundEffectsArgs(DEFAULT_SOUND_EFFECTS, '/tmp/work-review-demo/effects.wav');
+  const filter = valueAfter(args, '-filter_complex') ?? '';
+
+  assert.deepEqual(DEFAULT_SOUND_EFFECTS.map(({ kind }) => kind), [
+    'click',
+    'switch',
+    'complete',
+    'outro',
+  ]);
+  assert.equal(args.filter((arg) => arg === '-f').length, DEFAULT_SOUND_EFFECTS.length);
+  assert.match(args.join(' '), /sine=frequency=/);
+  assert.match(filter, /adelay=/);
+  assert.match(filter, /afade=t=out/);
+  assert.match(filter, /amix=inputs=4:normalize=0/);
+  assert.match(filter, /atrim=0:85/);
+});
+
+test('最终混音在旁白区间把音乐降低 10dB，并限制时长与峰值', () => {
+  const args = buildAudioMixArgs({
+    voiceoverPath: 'voiceover.wav',
+    musicPath: 'music.wav',
+    effectsPath: 'effects.wav',
+    outputPath: 'unmastered.wav',
+    voiceoverCues: [
+      { id: 'one', start: 0.35, end: 6.65, zh: '一', en: 'one' },
+      { id: 'two', start: 7.35, end: 18.65, zh: '二', en: 'two' },
+    ],
+  });
+  const filter = valueAfter(args, '-filter_complex') ?? '';
+
+  assert.match(filter, /volume=0\.316228/);
+  assert.match(filter, /between\(t,0\.350,6\.650\)/);
+  assert.match(filter, /between\(t,7\.350,18\.650\)/);
+  assert.match(filter, /amix=inputs=3:normalize=0/);
+  assert.match(filter, /alimiter=limit=0\.891251/);
+  assert.match(filter, /atrim=0:85/);
+  assert.match(filter, /apad=whole_dur=85/);
+});
+
+test('mixDemoAudio 依次执行原始混音、首遍分析和第二遍渲染', async () => {
+  const calls: Array<{ binary: string; args: readonly string[] }> = [];
+  const outputPath = '/tmp/work-review-demo/mix.wav';
+  const result = await mixDemoAudio({
+    voiceoverPath: '/tmp/work-review-demo/voiceover.wav',
+    musicPath: '/tmp/work-review-demo/music.wav',
+    effectsPath: '/tmp/work-review-demo/effects.wav',
+    outputPath,
+    voiceoverCues: [{ id: 'one', start: 0.35, end: 6.65, zh: '一', en: 'one' }],
+    ffmpegPath: '/mock/ffmpeg',
+    runner: async (binary, args) => {
+      calls.push({ binary, args });
+      if (args.includes('null')) {
+        return ok('', `{
+          "input_i":"-20.0",
+          "input_tp":"-3.0",
+          "input_lra":"3.0",
+          "input_thresh":"-30.0",
+          "target_offset":"0.2"
+        }`);
+      }
+      return ok();
+    },
+  });
+
+  assert.equal(result, outputPath);
+  assert.equal(calls.length, 3);
+  assert.ok(calls.every(({ binary }) => binary === '/mock/ffmpeg'));
+  assert.match(valueAfter(calls[1]?.args ?? [], '-af') ?? '', /print_format=json/);
+  assert.match(valueAfter(calls[2]?.args ?? [], '-af') ?? '', /measured_I=-20/);
+  assert.equal(calls[2]?.args.at(-1), outputPath);
+});

--- a/scripts/product-demo/ffmpeg.ts
+++ b/scripts/product-demo/ffmpeg.ts
@@ -1,0 +1,536 @@
+import { spawn } from 'node:child_process';
+import { constants as fsConstants } from 'node:fs';
+import { access } from 'node:fs/promises';
+import { delimiter, join } from 'node:path';
+import {
+  DEMO_DURATION_SECONDS,
+  DEMO_FPS,
+  DEMO_TOTAL_FRAMES,
+} from './storyboard.ts';
+
+const DEFAULT_CAPTURE_BYTES = 1024 * 1024;
+const LOUDNESS_FILTER = 'loudnorm=I=-14:TP=-1:LRA=7';
+
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface RunCommandOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  maxCaptureBytes?: number;
+  signal?: AbortSignal;
+}
+
+export type CommandRunner = (
+  binary: string,
+  args: readonly string[],
+  options?: RunCommandOptions,
+) => Promise<CommandResult>;
+
+export interface LoudnormMeasurement {
+  inputI: number;
+  inputTp: number;
+  inputLra: number;
+  inputThresh: number;
+  targetOffset: number;
+}
+
+export interface VideoProbe {
+  codec: string | null;
+  pixelFormat: string | null;
+  width: number | null;
+  height: number | null;
+  frameRate: number | null;
+  averageFrameRate: number | null;
+  frameCount: number | null;
+  durationSeconds: number | null;
+}
+
+export interface AudioProbe {
+  codec: string | null;
+  sampleRate: number | null;
+  channels: number | null;
+  channelLayout: string | null;
+  durationSeconds: number | null;
+}
+
+export interface MediaProbe {
+  durationSeconds: number | null;
+  formatName: string | null;
+  video: VideoProbe | null;
+  audio: AudioProbe | null;
+}
+
+interface ProbeStream {
+  codec_type?: unknown;
+  codec_name?: unknown;
+  pix_fmt?: unknown;
+  width?: unknown;
+  height?: unknown;
+  r_frame_rate?: unknown;
+  avg_frame_rate?: unknown;
+  nb_frames?: unknown;
+  nb_read_frames?: unknown;
+  duration?: unknown;
+  sample_rate?: unknown;
+  channels?: unknown;
+  channel_layout?: unknown;
+}
+
+interface ProbeDocument {
+  format?: {
+    duration?: unknown;
+    format_name?: unknown;
+  };
+  streams?: unknown;
+}
+
+interface CandidateOptions {
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  platform?: NodeJS.Platform;
+}
+
+export interface DiscoverMediaBinariesOptions extends CandidateOptions {
+  runner?: CommandRunner;
+  isExecutable?: (candidate: string) => Promise<boolean>;
+}
+
+export interface MediaBinaries {
+  ffmpeg: string;
+  ffprobe: string;
+}
+
+export interface ProbeMediaOptions {
+  ffprobePath?: string;
+  runner?: CommandRunner;
+  discovery?: DiscoverMediaBinariesOptions;
+}
+
+export interface FinalVideoOptions {
+  videoPath: string;
+  audioPath: string;
+  outputPath: string;
+  width: number;
+  height: number;
+}
+
+class BoundedTextCapture {
+  private buffer = Buffer.alloc(0);
+  private totalBytes = 0;
+
+  constructor(
+    private readonly limit: number,
+    private readonly retain: 'head' | 'tail' = 'head',
+  ) {}
+
+  append(chunk: Buffer | string): void {
+    const incoming = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    this.totalBytes += incoming.length;
+
+    if (this.retain === 'head') {
+      const remaining = this.limit - this.buffer.length;
+      if (remaining > 0) {
+        this.buffer = Buffer.concat([this.buffer, incoming.subarray(0, remaining)]);
+      }
+      return;
+    }
+
+    const combined = Buffer.concat([this.buffer, incoming]);
+    this.buffer = combined.length > this.limit
+      ? Buffer.from(combined.subarray(combined.length - this.limit))
+      : combined;
+  }
+
+  text(): string {
+    return this.buffer.toString('utf8');
+  }
+
+  get truncated(): boolean {
+    return this.totalBytes > this.buffer.length;
+  }
+}
+
+function assertNonEmpty(value: string, label: string): void {
+  if (!value.trim()) throw new Error(`${label}不能为空`);
+}
+
+function formatCommandFailure(
+  binary: string,
+  exitCode: number | null,
+  signal: NodeJS.Signals | null,
+  stderr: BoundedTextCapture,
+): Error {
+  const status = exitCode === null ? `信号 ${signal ?? 'unknown'}` : `退出码 ${exitCode}`;
+  const details = stderr.text().trim() || '无 stderr 输出';
+  const suffix = stderr.truncated ? '\n[stderr 已截断]' : '';
+  return new Error(`命令 ${binary} 执行失败（${status}）：${details}${suffix}`);
+}
+
+/**
+ * 使用参数数组启动子进程。这里显式禁用 shell，避免路径或字幕文本被解释为命令。
+ */
+export function runCommand(
+  binary: string,
+  args: readonly string[],
+  options: RunCommandOptions = {},
+): Promise<CommandResult> {
+  assertNonEmpty(binary, '可执行文件路径');
+  if (!Array.isArray(args) || args.some((arg) => typeof arg !== 'string')) {
+    return Promise.reject(new Error('命令参数必须是字符串数组'));
+  }
+
+  const maxCaptureBytes = options.maxCaptureBytes ?? DEFAULT_CAPTURE_BYTES;
+  if (!Number.isInteger(maxCaptureBytes) || maxCaptureBytes <= 0) {
+    return Promise.reject(new Error('maxCaptureBytes 必须是正整数'));
+  }
+
+  return new Promise((resolve, reject) => {
+    const stdout = new BoundedTextCapture(maxCaptureBytes, 'head');
+    const stderr = new BoundedTextCapture(maxCaptureBytes, 'tail');
+    const child = spawn(binary, [...args], {
+      cwd: options.cwd,
+      env: options.env,
+      signal: options.signal,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+
+    child.stdout.on('data', (chunk: Buffer) => stdout.append(chunk));
+    child.stderr.on('data', (chunk: Buffer) => stderr.append(chunk));
+    child.once('error', (error) => {
+      reject(new Error(`无法启动命令 ${binary}：${error.message}`));
+    });
+    child.once('close', (exitCode, signal) => {
+      if (exitCode !== 0) {
+        reject(formatCommandFailure(binary, exitCode, signal, stderr));
+        return;
+      }
+      resolve({
+        stdout: stdout.text(),
+        stderr: stderr.text(),
+        exitCode: 0,
+      });
+    });
+  });
+}
+
+function executableOverrideName(binary: 'ffmpeg' | 'ffprobe'): 'FFMPEG_PATH' | 'FFPROBE_PATH' {
+  return binary === 'ffmpeg' ? 'FFMPEG_PATH' : 'FFPROBE_PATH';
+}
+
+function executableNames(binary: 'ffmpeg' | 'ffprobe', platform: NodeJS.Platform): string[] {
+  if (platform === 'win32') return [`${binary}.exe`, binary];
+  return [binary];
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
+}
+
+/** 构建可审计、确定性的 ffmpeg/ffprobe 搜索顺序。 */
+export function buildExecutableCandidates(
+  binary: 'ffmpeg' | 'ffprobe',
+  options: CandidateOptions = {},
+): string[] {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const override = env[executableOverrideName(binary)];
+  const names = executableNames(binary, platform);
+  const pathEntries = (env.PATH ?? '')
+    .split(platform === 'win32' ? ';' : delimiter)
+    .filter(Boolean);
+  const candidates: string[] = [];
+
+  if (override) candidates.push(override);
+  for (const directory of pathEntries) {
+    for (const name of names) candidates.push(join(directory, name));
+  }
+
+  const commonDirectories = platform === 'darwin'
+    ? ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin']
+    : platform === 'linux'
+      ? ['/usr/local/bin', '/usr/bin', '/bin']
+      : [];
+  for (const directory of commonDirectories) {
+    for (const name of names) candidates.push(join(directory, name));
+  }
+
+  return unique(candidates);
+}
+
+async function defaultIsExecutable(candidate: string): Promise<boolean> {
+  try {
+    await access(candidate, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function discoverExecutable(
+  binary: 'ffmpeg' | 'ffprobe',
+  options: DiscoverMediaBinariesOptions,
+): Promise<string> {
+  const runner = options.runner ?? runCommand;
+  const isExecutable = options.isExecutable ?? defaultIsExecutable;
+  const candidates = buildExecutableCandidates(binary, options);
+
+  for (const candidate of candidates) {
+    if (!await isExecutable(candidate)) continue;
+    try {
+      await runner(candidate, ['-version'], { maxCaptureBytes: 64 * 1024 });
+      return candidate;
+    } catch {
+      // 文件存在不代表可正常运行，继续检查下一个候选项。
+    }
+  }
+
+  throw new Error(
+    `未找到可用的 ${binary}。请安装 FFmpeg 工具链，或通过 ${executableOverrideName(binary)} 指定可执行文件。`,
+  );
+}
+
+export async function discoverMediaBinaries(
+  options: DiscoverMediaBinariesOptions = {},
+): Promise<MediaBinaries> {
+  const ffmpeg = await discoverExecutable('ffmpeg', options);
+  const ffprobe = await discoverExecutable('ffprobe', options);
+  return { ffmpeg, ffprobe };
+}
+
+export function buildProbeArgs(mediaPath: string): string[] {
+  assertNonEmpty(mediaPath, '媒体路径');
+  return [
+    '-v', 'error',
+    '-count_frames',
+    '-show_streams',
+    '-show_format',
+    '-print_format', 'json',
+    mediaPath,
+  ];
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function optionalNumber(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value !== 'string' || !value.trim() || value === 'N/A') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function optionalInteger(value: unknown): number | null {
+  const parsed = optionalNumber(value);
+  return parsed !== null && Number.isInteger(parsed) ? parsed : null;
+}
+
+function parseRate(value: unknown): number | null {
+  if (typeof value !== 'string' || !value.trim() || value === 'N/A') return null;
+  const [numeratorText, denominatorText] = value.split('/');
+  if (denominatorText === undefined) return optionalNumber(value);
+  const numerator = Number(numeratorText);
+  const denominator = Number(denominatorText);
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator === 0) return null;
+  return numerator / denominator;
+}
+
+function streamDuration(stream: ProbeStream): number | null {
+  return optionalNumber(stream.duration);
+}
+
+function parseVideoStream(stream: ProbeStream): VideoProbe {
+  return {
+    codec: optionalString(stream.codec_name),
+    pixelFormat: optionalString(stream.pix_fmt),
+    width: optionalInteger(stream.width),
+    height: optionalInteger(stream.height),
+    frameRate: parseRate(stream.r_frame_rate),
+    averageFrameRate: parseRate(stream.avg_frame_rate),
+    frameCount: optionalInteger(stream.nb_read_frames) ?? optionalInteger(stream.nb_frames),
+    durationSeconds: streamDuration(stream),
+  };
+}
+
+function parseAudioStream(stream: ProbeStream): AudioProbe {
+  return {
+    codec: optionalString(stream.codec_name),
+    sampleRate: optionalInteger(stream.sample_rate),
+    channels: optionalInteger(stream.channels),
+    channelLayout: optionalString(stream.channel_layout),
+    durationSeconds: streamDuration(stream),
+  };
+}
+
+export function parseMediaProbe(stdout: string): MediaProbe {
+  let document: ProbeDocument;
+  try {
+    document = JSON.parse(stdout) as ProbeDocument;
+  } catch (error) {
+    throw new Error(`无法解析 ffprobe JSON 输出：${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (typeof document !== 'object' || document === null || Array.isArray(document)) {
+    throw new Error('ffprobe JSON 顶层必须是对象');
+  }
+
+  if (!Array.isArray(document.streams)) {
+    throw new Error('ffprobe JSON 缺少 streams 数组');
+  }
+  const streams = document.streams.filter(
+    (stream): stream is ProbeStream => typeof stream === 'object' && stream !== null,
+  );
+  const videoStream = streams.find((stream) => stream.codec_type === 'video');
+  const audioStream = streams.find((stream) => stream.codec_type === 'audio');
+  if (!videoStream && !audioStream) throw new Error('ffprobe 未发现音视频流');
+
+  const streamDurations = streams
+    .map(streamDuration)
+    .filter((value): value is number => value !== null);
+  const durationSeconds = optionalNumber(document.format?.duration)
+    ?? (streamDurations.length > 0 ? Math.max(...streamDurations) : null);
+
+  return {
+    durationSeconds,
+    formatName: optionalString(document.format?.format_name),
+    video: videoStream ? parseVideoStream(videoStream) : null,
+    audio: audioStream ? parseAudioStream(audioStream) : null,
+  };
+}
+
+export async function probeMedia(
+  mediaPath: string,
+  options: ProbeMediaOptions = {},
+): Promise<MediaProbe> {
+  const runner = options.runner ?? runCommand;
+  const ffprobePath = options.ffprobePath
+    ?? await discoverExecutable('ffprobe', { ...options.discovery, runner });
+  const result = await runner(ffprobePath, buildProbeArgs(mediaPath));
+  return parseMediaProbe(result.stdout);
+}
+
+function assertDimension(value: number, label: string): void {
+  if (!Number.isInteger(value) || value <= 0 || value % 2 !== 0) {
+    throw new Error(`${label}必须是正偶数`);
+  }
+}
+
+/** 构建最终 MP4 的固定发布参数；所有路径均保留为独立 argv 元素。 */
+export function buildFinalVideoArgs(options: FinalVideoOptions): string[] {
+  assertNonEmpty(options.videoPath, '视频输入路径');
+  assertNonEmpty(options.audioPath, '音频输入路径');
+  assertNonEmpty(options.outputPath, '视频输出路径');
+  assertDimension(options.width, '视频宽度');
+  assertDimension(options.height, '视频高度');
+
+  return [
+    '-hide_banner',
+    '-nostdin',
+    '-y',
+    '-i', options.videoPath,
+    '-i', options.audioPath,
+    '-map', '0:v:0',
+    '-map', '1:a:0',
+    '-vf', `scale=${options.width}:${options.height}:flags=lanczos,setsar=1,fps=${DEMO_FPS}`,
+    '-r', String(DEMO_FPS),
+    '-fps_mode', 'cfr',
+    '-frames:v', String(DEMO_TOTAL_FRAMES),
+    '-c:v', 'libx264',
+    '-preset', 'slow',
+    '-crf', '18',
+    '-pix_fmt', 'yuv420p',
+    '-c:a', 'aac',
+    '-b:a', '192k',
+    '-ar', '48000',
+    '-ac', '2',
+    '-t', DEMO_DURATION_SECONDS.toFixed(3),
+    '-movflags', '+faststart',
+    options.outputPath,
+  ];
+}
+
+export function buildLoudnormAnalysisArgs(inputPath: string): string[] {
+  assertNonEmpty(inputPath, '响度分析输入路径');
+  return [
+    '-hide_banner',
+    '-nostdin',
+    '-i', inputPath,
+    '-af', `${LOUDNESS_FILTER}:print_format=json`,
+    '-f', 'null',
+    '-',
+  ];
+}
+
+function finiteLoudnormField(
+  record: Record<string, unknown>,
+  sourceName: string,
+  targetName: keyof LoudnormMeasurement,
+  target: Partial<LoudnormMeasurement>,
+): void {
+  const parsed = optionalNumber(record[sourceName]);
+  if (parsed === null) throw new Error(`loudnorm 首遍结果缺少有效字段 ${sourceName}`);
+  target[targetName] = parsed;
+}
+
+export function parseLoudnormMeasurement(stderr: string): LoudnormMeasurement {
+  const jsonBlocks = stderr.match(/\{[^{}]*\}/gs) ?? [];
+  for (const block of jsonBlocks.reverse()) {
+    let record: Record<string, unknown>;
+    try {
+      record = JSON.parse(block) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (!('input_i' in record)) continue;
+
+    const measurement: Partial<LoudnormMeasurement> = {};
+    finiteLoudnormField(record, 'input_i', 'inputI', measurement);
+    finiteLoudnormField(record, 'input_tp', 'inputTp', measurement);
+    finiteLoudnormField(record, 'input_lra', 'inputLra', measurement);
+    finiteLoudnormField(record, 'input_thresh', 'inputThresh', measurement);
+    finiteLoudnormField(record, 'target_offset', 'targetOffset', measurement);
+    return measurement as LoudnormMeasurement;
+  }
+  throw new Error('未在 FFmpeg stderr 中找到有效的 loudnorm JSON 字段');
+}
+
+export function buildLoudnormRenderArgs(
+  inputPath: string,
+  outputPath: string,
+  measurement: LoudnormMeasurement,
+): string[] {
+  assertNonEmpty(inputPath, '响度渲染输入路径');
+  assertNonEmpty(outputPath, '响度渲染输出路径');
+  const values = Object.values(measurement);
+  if (values.some((value) => !Number.isFinite(value))) {
+    throw new Error('loudnorm 测量值必须全部为有限数');
+  }
+
+  const filter = [
+    LOUDNESS_FILTER,
+    `measured_I=${measurement.inputI}`,
+    `measured_TP=${measurement.inputTp}`,
+    `measured_LRA=${measurement.inputLra}`,
+    `measured_thresh=${measurement.inputThresh}`,
+    `offset=${measurement.targetOffset}`,
+    'linear=true',
+    'print_format=summary',
+  ].join(':');
+
+  return [
+    '-hide_banner',
+    '-nostdin',
+    '-y',
+    '-i', inputPath,
+    '-af', filter,
+    '-ar', '48000',
+    '-ac', '2',
+    '-c:a', 'pcm_s24le',
+    '-t', DEMO_DURATION_SECONDS.toFixed(3),
+    outputPath,
+  ];
+}

--- a/scripts/product-demo/fixtures.test.ts
+++ b/scripts/product-demo/fixtures.test.ts
@@ -16,16 +16,28 @@ test('演示夹具锁定日期、时区、活动和统计', () => {
     { time: '16:40', app: 'Terminal', title: 'npm run verify:frontend' },
   ]);
   assert.equal(fixtures.stats.workTimeDuration, 19_800);
-  assert.equal(
-    fixtures.stats.categories.reduce((total, item) => total + item.duration, 0),
-    fixtures.stats.workTimeDuration,
-  );
+  const totals = {
+    activities: fixtures.activities.reduce((total, item) => total + item.duration, 0),
+    apps: fixtures.stats.apps.reduce((total, item) => total + item.duration, 0),
+    categories: fixtures.stats.categories.reduce((total, item) => total + item.duration, 0),
+    hourly: fixtures.stats.hourlyActivity.reduce((total, item) => total + item.duration, 0),
+  };
+  assert.deepEqual(totals, {
+    activities: fixtures.stats.workTimeDuration,
+    apps: fixtures.stats.workTimeDuration,
+    categories: fixtures.stats.workTimeDuration,
+    hourly: fixtures.stats.workTimeDuration,
+  });
 });
 
 test('日报和助手回答符合批准规格', () => {
   const fixtures = createDemoFixtures();
   assert.ok(fixtures.report.sections.length >= 4);
   assert.match(fixtures.assistant.basicAnswer, /5 小时 30 分钟/);
+  assert.match(fixtures.assistant.basicAnswer, /开发 3 小时 10 分钟（57\.6%）/);
+  assert.match(fixtures.assistant.basicAnswer, /办公 1 小时 10 分钟（21\.2%）/);
+  assert.match(fixtures.assistant.basicAnswer, /沟通 45 分钟（13\.6%）/);
+  assert.match(fixtures.assistant.basicAnswer, /浏览 25 分钟（7\.6%）/);
   assert.match(fixtures.assistant.basicAnswer, /Cursor/);
   assert.match(fixtures.assistant.aiAnswer, /16:40/);
   assert.equal(fixtures.activities.find((activity) => activity.time === '16:40')?.title, 'npm run verify:frontend');

--- a/scripts/product-demo/fixtures.test.ts
+++ b/scripts/product-demo/fixtures.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createDemoFixtures } from './fixtures.ts';
+
+test('演示夹具锁定日期、时区、活动和统计', () => {
+  const fixtures = createDemoFixtures();
+  assert.equal(fixtures.date, '2026-08-12');
+  assert.equal(fixtures.timezone, 'Asia/Shanghai');
+  assert.deepEqual(fixtures.activities.map(({ time, app, title }) => ({ time, app, title })), [
+    { time: '09:12', app: 'Cursor', title: 'Aurora Board · 导出流程' },
+    { time: '10:36', app: '浏览器', title: '设计规格复核 · docs.example.test' },
+    { time: '11:18', app: '文档', title: 'Aurora Board 发布检查清单' },
+    { time: '14:03', app: '会议', title: 'Aurora Board 周会' },
+    { time: '15:24', app: 'Figma', title: '日报空态与竖屏构图' },
+    { time: '16:40', app: 'Terminal', title: 'npm run verify:frontend' },
+  ]);
+  assert.equal(fixtures.stats.workTimeDuration, 19_800);
+  assert.equal(
+    fixtures.stats.categories.reduce((total, item) => total + item.duration, 0),
+    fixtures.stats.workTimeDuration,
+  );
+});
+
+test('日报和助手回答符合批准规格', () => {
+  const fixtures = createDemoFixtures();
+  assert.ok(fixtures.report.sections.length >= 4);
+  assert.match(fixtures.assistant.basicAnswer, /5 小时 30 分钟/);
+  assert.match(fixtures.assistant.basicAnswer, /Cursor/);
+  assert.match(fixtures.assistant.aiAnswer, /16:40/);
+  assert.equal(fixtures.activities.find((activity) => activity.time === '16:40')?.title, 'npm run verify:frontend');
+  assert.equal(fixtures.assistant.basicQuestion, '今天主要做了什么？');
+  assert.equal(
+    fixtures.assistant.aiQuestion,
+    '结合刚才的今日记录，再查今天的活动，提炼一项有依据的日报成果。',
+  );
+});
+
+test('夹具深拷贝且所有绝对路径限定在安全目录', () => {
+  const first = createDemoFixtures();
+  const second = createDemoFixtures();
+  first.activities[0].title = '已修改';
+  assert.notEqual(second.activities[0].title, '已修改');
+
+  const serialized = JSON.stringify(second);
+  const absolutePaths = serialized.match(/\/(?:[^"\\]|\\.)+/g) ?? [];
+  for (const path of absolutePaths) {
+    if (path.startsWith('/tmp/')) {
+      assert.ok(path.startsWith('/tmp/work-review-demo/'), path);
+    }
+  }
+  assert.doesNotMatch(serialized, /\/Users\//);
+  assert.doesNotMatch(serialized, /github\.com|openai\.com/);
+});

--- a/scripts/product-demo/fixtures.ts
+++ b/scripts/product-demo/fixtures.ts
@@ -1,0 +1,107 @@
+import type { DemoFixtures } from './types.ts';
+import { DEMO_DATE, DEMO_TIMEZONE } from './storyboard.ts';
+
+const SAFE_ROOT = '/tmp/work-review-demo/';
+const epoch = (time: string) => Math.floor(Date.parse(`${DEMO_DATE}T${time}:00+08:00`) / 1000);
+
+const REPORT_SECTIONS = [
+  {
+    title: '今日概览',
+    markdown: '全天有效投入 **5 小时 30 分钟**。工作围绕 Aurora Board 导出流程、发布检查清单和日报体验验证展开。',
+  },
+  {
+    title: '重点进展',
+    markdown: '- 完成 Aurora Board 导出流程实现与端到端验证。\n- 整理发布检查清单并复核设计规格。\n- 完成日报空态与竖屏构图方案。',
+  },
+  {
+    title: '专注与协作',
+    markdown: '开发投入 3 小时 10 分钟，办公 1 小时 10 分钟，沟通 45 分钟，浏览 25 分钟；14:03 的周会集中同步了发布范围。',
+  },
+  {
+    title: '明日计划',
+    markdown: '1. 跟进导出边界场景。\n2. 完成发布前回归。\n3. 整理演示反馈。',
+  },
+];
+
+function buildReportContent(): string {
+  return [
+    '# 2026 年 8 月 12 日工作日报',
+    '> 今天聚焦 Aurora Board 导出流程与发布验证。',
+    ...REPORT_SECTIONS.flatMap((section) => [`## ${section.title}`, section.markdown]),
+  ].join('\n\n');
+}
+
+const TEMPLATE: DemoFixtures = {
+  date: DEMO_DATE,
+  timezone: DEMO_TIMEZONE,
+  locale: 'zh-CN',
+  project: 'Aurora Board',
+  safeRoot: SAFE_ROOT,
+  dataDir: `${SAFE_ROOT}data/`,
+  exportPath: `${SAFE_ROOT}exports/${DEMO_DATE}.md`,
+  activities: [
+    { id: 101, time: '09:12', timestamp: epoch('09:12'), app: 'Cursor', title: 'Aurora Board · 导出流程', category: 'development', duration: 6_300, browserUrl: null, screenshotPath: `${SAFE_ROOT}screenshots/cursor-export.png`, ocrText: 'export_report_markdown · Aurora Board' },
+    { id: 102, time: '10:36', timestamp: epoch('10:36'), app: '浏览器', title: '设计规格复核 · docs.example.test', category: 'browser', duration: 1_500, browserUrl: 'https://docs.example.test/aurora-board/spec', screenshotPath: `${SAFE_ROOT}screenshots/spec-review.png`, ocrText: 'Aurora Board 产品演示规格' },
+    { id: 103, time: '11:18', timestamp: epoch('11:18'), app: '文档', title: 'Aurora Board 发布检查清单', category: 'office', duration: 2_700, browserUrl: null, screenshotPath: `${SAFE_ROOT}screenshots/release-checklist.png`, ocrText: '发布检查清单：导出、验证、回归' },
+    { id: 104, time: '14:03', timestamp: epoch('14:03'), app: '会议', title: 'Aurora Board 周会', category: 'communication', duration: 2_700, browserUrl: null, screenshotPath: `${SAFE_ROOT}screenshots/weekly-meeting.png`, ocrText: 'Aurora Board 周会 · 发布范围同步' },
+    { id: 105, time: '15:24', timestamp: epoch('15:24'), app: 'Figma', title: '日报空态与竖屏构图', category: 'office', duration: 1_500, browserUrl: null, screenshotPath: `${SAFE_ROOT}screenshots/vertical-layout.png`, ocrText: '日报空态 · 9:16 构图' },
+    { id: 106, time: '16:40', timestamp: epoch('16:40'), app: 'Terminal', title: 'npm run verify:frontend', category: 'development', duration: 3_600, browserUrl: null, screenshotPath: `${SAFE_ROOT}screenshots/frontend-verify.png`, ocrText: 'svelte-check 0 errors · tests passed · vite build complete' },
+  ],
+  stats: {
+    totalDuration: 19_800,
+    workTimeDuration: 19_800,
+    screenshotCount: 146,
+    categories: [
+      { category: 'development', duration: 11_400 },
+      { category: 'office', duration: 4_200 },
+      { category: 'communication', duration: 2_700 },
+      { category: 'browser', duration: 1_500 },
+    ],
+    apps: [
+      { appName: 'Cursor', duration: 6_300, count: 42 },
+      { appName: 'Terminal', duration: 3_600, count: 18 },
+      { appName: '文档', duration: 2_700, count: 16 },
+      { appName: '会议', duration: 2_700, count: 6 },
+      { appName: '浏览器', duration: 1_500, count: 12 },
+      { appName: 'Figma', duration: 1_500, count: 10 },
+    ],
+    hourlyActivity: Array.from({ length: 24 }, (_, hour) => ({
+      hour,
+      duration: ({ 9: 2_880, 10: 2_700, 11: 2_520, 14: 2_700, 15: 2_700, 16: 4_500, 17: 1_800 } as Record<number, number>)[hour] ?? 0,
+    })),
+  },
+  report: {
+    createdAt: epoch('17:30'),
+    sections: REPORT_SECTIONS,
+    content: buildReportContent(),
+  },
+  assistant: {
+    conversationId: 7_001,
+    basicQuestion: '今天主要做了什么？',
+    basicAnswer: '今天共记录有效工作 5 小时 30 分钟。开发 3 小时 10 分钟，办公 1 小时 10 分钟，沟通 45 分钟，浏览 25 分钟。使用最多的应用包括 Cursor、Terminal 和文档；当天还使用了浏览器、会议与 Figma。',
+    aiQuestion: '结合刚才的今日记录，再查今天的活动，提炼一项有依据的日报成果。',
+    aiAnswer: '最值得写进日报的成果，是完成 Aurora Board 导出流程的端到端验证，并整理发布检查清单。依据包括上午的实现与文档记录，以及 16:40 执行的前端验证。',
+    modelProfile: {
+      id: 'demo-ai',
+      name: '演示 AI',
+      model_config: {
+        provider: 'ollama',
+        endpoint: 'http://127.0.0.1:11434',
+        api_key: null,
+        model: 'demo-local-7b',
+      },
+    },
+  },
+  privacy: {
+    appRules: [
+      { app_name: 'Cursor', level: 'full' },
+      { app_name: '浏览器', level: 'anonymized' },
+      { app_name: '会议', level: 'ignored' },
+    ],
+    screenshotsEnabled: true,
+  },
+};
+
+export function createDemoFixtures(): DemoFixtures {
+  return structuredClone(TEMPLATE);
+}

--- a/scripts/product-demo/fixtures.ts
+++ b/scripts/product-demo/fixtures.ts
@@ -45,7 +45,7 @@ const TEMPLATE: DemoFixtures = {
     { id: 103, time: '11:18', timestamp: epoch('11:18'), app: '文档', title: 'Aurora Board 发布检查清单', category: 'office', duration: 2_700, browserUrl: null, screenshotPath: `${SAFE_ROOT}screenshots/release-checklist.png`, ocrText: '发布检查清单：导出、验证、回归' },
     { id: 104, time: '14:03', timestamp: epoch('14:03'), app: '会议', title: 'Aurora Board 周会', category: 'communication', duration: 2_700, browserUrl: null, screenshotPath: `${SAFE_ROOT}screenshots/weekly-meeting.png`, ocrText: 'Aurora Board 周会 · 发布范围同步' },
     { id: 105, time: '15:24', timestamp: epoch('15:24'), app: 'Figma', title: '日报空态与竖屏构图', category: 'office', duration: 1_500, browserUrl: null, screenshotPath: `${SAFE_ROOT}screenshots/vertical-layout.png`, ocrText: '日报空态 · 9:16 构图' },
-    { id: 106, time: '16:40', timestamp: epoch('16:40'), app: 'Terminal', title: 'npm run verify:frontend', category: 'development', duration: 3_600, browserUrl: null, screenshotPath: `${SAFE_ROOT}screenshots/frontend-verify.png`, ocrText: 'svelte-check 0 errors · tests passed · vite build complete' },
+    { id: 106, time: '16:40', timestamp: epoch('16:40'), app: 'Terminal', title: 'npm run verify:frontend', category: 'development', duration: 5_100, browserUrl: null, screenshotPath: `${SAFE_ROOT}screenshots/frontend-verify.png`, ocrText: 'svelte-check 0 errors · tests passed · vite build complete' },
   ],
   stats: {
     totalDuration: 19_800,
@@ -59,7 +59,7 @@ const TEMPLATE: DemoFixtures = {
     ],
     apps: [
       { appName: 'Cursor', duration: 6_300, count: 42 },
-      { appName: 'Terminal', duration: 3_600, count: 18 },
+      { appName: 'Terminal', duration: 5_100, count: 18 },
       { appName: '文档', duration: 2_700, count: 16 },
       { appName: '会议', duration: 2_700, count: 6 },
       { appName: '浏览器', duration: 1_500, count: 12 },
@@ -78,7 +78,7 @@ const TEMPLATE: DemoFixtures = {
   assistant: {
     conversationId: 7_001,
     basicQuestion: '今天主要做了什么？',
-    basicAnswer: '今天共记录有效工作 5 小时 30 分钟。开发 3 小时 10 分钟，办公 1 小时 10 分钟，沟通 45 分钟，浏览 25 分钟。使用最多的应用包括 Cursor、Terminal 和文档；当天还使用了浏览器、会议与 Figma。',
+    basicAnswer: '今天共记录有效工作 5 小时 30 分钟。开发 3 小时 10 分钟（57.6%），办公 1 小时 10 分钟（21.2%），沟通 45 分钟（13.6%），浏览 25 分钟（7.6%）。使用最多的应用包括 Cursor、Terminal 和文档；当天还使用了浏览器、会议与 Figma。',
     aiQuestion: '结合刚才的今日记录，再查今天的活动，提炼一项有依据的日报成果。',
     aiAnswer: '最值得写进日报的成果，是完成 Aurora Board 导出流程的端到端验证，并整理发布检查清单。依据包括上午的实现与文档记录，以及 16:40 执行的前端验证。',
     modelProfile: {

--- a/scripts/product-demo/ocr.test.ts
+++ b/scripts/product-demo/ocr.test.ts
@@ -1,0 +1,369 @@
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import type { CommandResult, CommandRunner } from './ffmpeg.ts';
+import {
+  OCR_ASPECTS,
+  OCR_FRAME_KINDS,
+  buildKeyframeOcrInputs,
+  extractKeyframeOcr,
+  type KeyframeOcrInput,
+} from './ocr.ts';
+import { STORYBOARD } from './storyboard.ts';
+
+const ok = (stdout = '', stderr = ''): CommandResult => ({
+  stdout,
+  stderr,
+  exitCode: 0,
+});
+
+async function createExecutable(filePath: string): Promise<void> {
+  await writeFile(filePath, '#!/bin/sh\nexit 0\n', 'utf8');
+  await chmod(filePath, 0o755);
+}
+
+async function createFrameFiles(inputs: readonly KeyframeOcrInput[]): Promise<void> {
+  await Promise.all(inputs.map(async (input) => {
+    await mkdir(path.dirname(input.imagePath), { recursive: true });
+    await writeFile(input.imagePath, 'safe png fixture', 'utf8');
+  }));
+}
+
+function reverseInputs(inputs: readonly KeyframeOcrInput[]): KeyframeOcrInput[] {
+  return [...inputs].reverse();
+}
+
+test('构建横竖屏七镜头 start/action/end 的确定性 42 帧 OCR 输入', () => {
+  const intermediateDir = '/tmp/work-review-demo/intermediate';
+  const inputs = buildKeyframeOcrInputs(intermediateDir);
+
+  assert.equal(inputs.length, 42);
+  assert.deepEqual(
+    inputs.map(({ aspect, scene, frame }) => `${aspect}/${scene}/${frame}`),
+    OCR_ASPECTS.flatMap((aspect) => STORYBOARD.flatMap((scene) => (
+      OCR_FRAME_KINDS.map((frame) => `${aspect}/${scene.id}/${frame}`)
+    ))),
+  );
+  assert.equal(
+    inputs[0]?.imagePath,
+    '/tmp/work-review-demo/intermediate/16x9/hook-start.png',
+  );
+  assert.equal(
+    inputs.at(-1)?.imagePath,
+    '/tmp/work-review-demo/intermediate/9x16/outro-end.png',
+  );
+});
+
+test('通过 macOS Vision 批量提取真实图片 OCR，并生成确定性 UTF-8 文本与无绝对路径清单', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'work-review-ocr ;$(touch nope)-'));
+  const intermediateDir = path.join(root, 'input frames');
+  const outputDir = path.join(root, 'ocr output');
+  const swiftCompilerPath = path.join(root, 'fake swiftc');
+  const inputs = buildKeyframeOcrInputs(intermediateDir);
+  await createExecutable(swiftCompilerPath);
+  await createFrameFiles(inputs);
+
+  const calls: Array<{ binary: string; args: readonly string[] }> = [];
+  let helperSource = '';
+  const runner: CommandRunner = async (binary, args) => {
+    calls.push({ binary, args: [...args] });
+    if (binary === swiftCompilerPath) {
+      const sourcePath = args.find((arg) => arg.endsWith('.swift'));
+      const outputIndex = args.indexOf('-o');
+      const helperPath = args[outputIndex + 1];
+      const moduleCacheIndex = args.indexOf('-module-cache-path');
+      const moduleCachePath = args[moduleCacheIndex + 1];
+      assert.ok(sourcePath, '编译命令必须传入 Swift 源文件路径');
+      assert.ok(helperPath, '编译命令必须通过独立参数传入输出路径');
+      assert.ok(moduleCacheIndex >= 0, '编译命令必须使用隔离的 Swift 模块缓存');
+      assert.ok(moduleCachePath && path.isAbsolute(moduleCachePath));
+      assert.equal(path.basename(moduleCachePath), 'module-cache');
+      helperSource = await readFile(sourcePath, 'utf8');
+      await createExecutable(helperPath);
+      return ok();
+    }
+
+    assert.equal(args.length, inputs.length * 2);
+    for (let index = 0; index < args.length; index += 2) {
+      const imagePath = args[index];
+      const rawOutputPath = args[index + 1];
+      assert.ok(imagePath);
+      assert.ok(rawOutputPath);
+      await mkdir(path.dirname(rawOutputPath), { recursive: true });
+      const order = index / 2;
+      const text = order === 0
+        ? '  今天完成 Aurora Notes 隐私设置\r\nAI 为可选增强  '
+        : `安全演示帧 ${order + 1}`;
+      await writeFile(rawOutputPath, text, 'utf8');
+    }
+    return ok();
+  };
+
+  try {
+    const result = await extractKeyframeOcr({
+      inputs: reverseInputs(inputs),
+      outputDir,
+      platform: 'darwin',
+      swiftCompilerPath,
+      runner,
+    });
+
+    assert.equal(calls.length, 2, 'Vision 帮助程序应只编译一次并批量处理全部图片');
+    assert.equal(calls[0]?.binary, swiftCompilerPath);
+    assert.match(helperSource, /import Vision/);
+    assert.match(helperSource, /VNRecognizeTextRequest/);
+    assert.match(helperSource, /zh-Hans/);
+    assert.match(helperSource, /en-US/);
+
+    const ocrCall = calls[1];
+    assert.ok(ocrCall);
+    assert.equal(ocrCall.args[0], inputs[0]?.imagePath);
+    assert.equal(ocrCall.args[2], inputs[1]?.imagePath);
+    assert.ok(ocrCall.args.includes(inputs[0]!.imagePath));
+    assert.ok(!ocrCall.args.some((arg) => arg.includes(`"${inputs[0]!.imagePath}"`)));
+
+    assert.equal(result.textFiles.length, 42);
+    assert.equal(
+      result.textFiles[0],
+      path.join(outputDir, '16x9', 'hook-start.txt'),
+    );
+    assert.equal(
+      await readFile(result.textFiles[0]!, 'utf8'),
+      '今天完成 Aurora Notes 隐私设置\nAI 为可选增强\n',
+    );
+
+    const manifestText = await readFile(result.manifestPath, 'utf8');
+    const manifest = JSON.parse(manifestText) as {
+      schemaVersion: number;
+      engine: string;
+      recognitionLanguages: string[];
+      entryCount: number;
+      entries: Array<{
+        aspect: string;
+        scene: string;
+        frame: string;
+        sourceFile: string;
+        textFile: string;
+        characterCount: number;
+      }>;
+    };
+    assert.equal(manifest.schemaVersion, 1);
+    assert.equal(manifest.engine, 'macos-vision');
+    assert.deepEqual(manifest.recognitionLanguages, ['zh-Hans', 'en-US']);
+    assert.equal(manifest.entryCount, 42);
+    assert.deepEqual(manifest.entries[0], {
+      aspect: '16x9',
+      scene: 'hook',
+      frame: 'start',
+      sourceFile: '16x9/hook-start.png',
+      textFile: '16x9/hook-start.txt',
+      characterCount: 31,
+    });
+    assert.deepEqual(
+      manifest.entries.map((entry) => `${entry.aspect}/${entry.scene}/${entry.frame}`),
+      inputs.map(({ aspect, scene, frame }) => `${aspect}/${scene}/${frame}`),
+    );
+    assert.ok(!manifestText.includes(root), 'OCR 清单不得泄漏真实绝对目录');
+    assert.ok(manifestText.endsWith('\n'));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('拒绝缺帧、重复帧和非绝对路径，避免隐私扫描覆盖不完整', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'work-review-ocr-invalid-'));
+  const compiler = path.join(root, 'swiftc');
+  const inputs = buildKeyframeOcrInputs(path.join(root, 'frames'));
+  await createExecutable(compiler);
+
+  try {
+    await assert.rejects(
+      extractKeyframeOcr({
+        inputs: inputs.slice(0, -1),
+        outputDir: path.join(root, 'output'),
+        platform: 'darwin',
+        swiftCompilerPath: compiler,
+        runner: async () => ok(),
+      }),
+      /必须完整包含 42 张关键帧.*缺少 9x16\/outro\/end/,
+    );
+
+    await assert.rejects(
+      extractKeyframeOcr({
+        inputs: [...inputs.slice(0, -1), inputs[0]!],
+        outputDir: path.join(root, 'output'),
+        platform: 'darwin',
+        swiftCompilerPath: compiler,
+        runner: async () => ok(),
+      }),
+      /重复的 OCR 关键帧.*16x9\/hook\/start/,
+    );
+
+    await assert.rejects(
+      extractKeyframeOcr({
+        inputs: inputs.map((input, index) => index === 0
+          ? { ...input, imagePath: 'relative/hook-start.png' }
+          : input),
+        outputDir: path.join(root, 'output'),
+        platform: 'darwin',
+        swiftCompilerPath: compiler,
+        runner: async () => ok(),
+      }),
+      /图片路径必须是绝对路径.*relative\/hook-start\.png/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('图片缺失、Swift 工具缺失和非 macOS 环境都明确失败', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'work-review-ocr-prerequisite-'));
+  const inputs = buildKeyframeOcrInputs(path.join(root, 'frames'));
+  const compiler = path.join(root, 'swiftc');
+  await createExecutable(compiler);
+  await createFrameFiles(inputs.slice(1));
+
+  try {
+    await assert.rejects(
+      extractKeyframeOcr({
+        inputs,
+        outputDir: path.join(root, 'output'),
+        platform: 'darwin',
+        swiftCompilerPath: compiler,
+        runner: async () => ok(),
+      }),
+      /OCR 图片不存在或不可读取.*hook-start\.png/,
+    );
+
+    await writeFile(inputs[0]!.imagePath, 'safe png fixture', 'utf8');
+    await assert.rejects(
+      extractKeyframeOcr({
+        inputs,
+        outputDir: path.join(root, 'output'),
+        platform: 'darwin',
+        swiftCompilerPath: path.join(root, 'missing-swiftc'),
+        runner: async () => ok(),
+      }),
+      /macOS Vision OCR 编译工具不可用/,
+    );
+
+    await assert.rejects(
+      extractKeyframeOcr({
+        inputs,
+        outputDir: path.join(root, 'output'),
+        platform: 'linux',
+        swiftCompilerPath: compiler,
+        runner: async () => ok(),
+      }),
+      /仅支持 macOS Vision/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('编译失败、OCR 执行失败和任一输出缺失都明确失败', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'work-review-ocr-failure-'));
+  const inputs = buildKeyframeOcrInputs(path.join(root, 'frames'));
+  const compiler = path.join(root, 'swiftc');
+  await createExecutable(compiler);
+  await createFrameFiles(inputs);
+
+  try {
+    await assert.rejects(
+      extractKeyframeOcr({
+        inputs,
+        outputDir: path.join(root, 'compile-output'),
+        platform: 'darwin',
+        swiftCompilerPath: compiler,
+        runner: async () => ({ stdout: '', stderr: 'Vision 模块不可用', exitCode: 1 }),
+      }),
+      /编译 macOS Vision OCR 帮助程序失败.*Vision 模块不可用/,
+    );
+
+    let call = 0;
+    await assert.rejects(
+      extractKeyframeOcr({
+        inputs,
+        outputDir: path.join(root, 'run-output'),
+        platform: 'darwin',
+        swiftCompilerPath: compiler,
+        runner: async (_binary, args) => {
+          call += 1;
+          if (call === 1) {
+            const helperPath = args[args.indexOf('-o') + 1]!;
+            await createExecutable(helperPath);
+            return ok();
+          }
+          throw new Error('无法解码 PNG');
+        },
+      }),
+      /执行 macOS Vision OCR 失败.*无法解码 PNG/,
+    );
+
+    call = 0;
+    await assert.rejects(
+      extractKeyframeOcr({
+        inputs,
+        outputDir: path.join(root, 'missing-output'),
+        platform: 'darwin',
+        swiftCompilerPath: compiler,
+        runner: async (_binary, args) => {
+          call += 1;
+          if (call === 1) {
+            const helperPath = args[args.indexOf('-o') + 1]!;
+            await createExecutable(helperPath);
+            return ok();
+          }
+          for (let index = 1; index < args.length - 2; index += 2) {
+            await mkdir(path.dirname(args[index]!), { recursive: true });
+            await writeFile(args[index]!, '可见文本', 'utf8');
+          }
+          return ok();
+        },
+      }),
+      /OCR 输出缺失.*9x16\/outro\/end/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('成功返回前已实际写入全部清单文件', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'work-review-ocr-result-'));
+  const inputs = buildKeyframeOcrInputs(path.join(root, 'frames'));
+  const compiler = path.join(root, 'swiftc');
+  await createExecutable(compiler);
+  await createFrameFiles(inputs);
+  let call = 0;
+
+  const runner: CommandRunner = async (_binary, args) => {
+    call += 1;
+    if (call === 1) {
+      const helperPath = args[args.indexOf('-o') + 1]!;
+      await createExecutable(helperPath);
+      return ok();
+    }
+    for (let index = 1; index < args.length; index += 2) {
+      await mkdir(path.dirname(args[index]!), { recursive: true });
+      await writeFile(args[index]!, '', 'utf8');
+    }
+    return ok();
+  };
+
+  try {
+    const result = await extractKeyframeOcr({
+      inputs,
+      outputDir: path.join(root, 'ocr'),
+      platform: 'darwin',
+      swiftCompilerPath: compiler,
+      runner,
+    });
+    await stat(result.manifestPath);
+    await Promise.all(result.textFiles.map((textFile) => stat(textFile)));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/product-demo/ocr.ts
+++ b/scripts/product-demo/ocr.ts
@@ -1,0 +1,400 @@
+import { constants as fsConstants } from 'node:fs';
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { runCommand, type CommandResult, type CommandRunner } from './ffmpeg.ts';
+import { STORYBOARD } from './storyboard.ts';
+import type { DemoAspect, StoryboardSceneId } from './types.ts';
+
+export const OCR_ASPECTS = ['16x9', '9x16'] as const satisfies readonly DemoAspect[];
+export const OCR_FRAME_KINDS = ['start', 'action', 'end'] as const;
+export const OCR_RECOGNITION_LANGUAGES = ['zh-Hans', 'en-US'] as const;
+export const OCR_MANIFEST_FILENAME = 'manifest.json';
+
+export type OcrFrameKind = typeof OCR_FRAME_KINDS[number];
+
+export interface KeyframeOcrInput {
+  aspect: DemoAspect;
+  scene: StoryboardSceneId;
+  frame: OcrFrameKind;
+  imagePath: string;
+}
+
+export interface KeyframeOcrManifestEntry {
+  aspect: DemoAspect;
+  scene: StoryboardSceneId;
+  frame: OcrFrameKind;
+  sourceFile: string;
+  textFile: string;
+  characterCount: number;
+}
+
+export interface KeyframeOcrManifest {
+  schemaVersion: 1;
+  engine: 'macos-vision';
+  recognitionLanguages: string[];
+  entryCount: number;
+  entries: KeyframeOcrManifestEntry[];
+}
+
+export interface ExtractKeyframeOcrOptions {
+  inputs: readonly KeyframeOcrInput[];
+  outputDir: string;
+  runner?: CommandRunner;
+  platform?: NodeJS.Platform;
+  swiftCompilerPath?: string;
+}
+
+export interface KeyframeOcrResult {
+  outputDir: string;
+  manifestPath: string;
+  textFiles: string[];
+  manifest: KeyframeOcrManifest;
+}
+
+interface CanonicalOcrFrame {
+  aspect: DemoAspect;
+  scene: StoryboardSceneId;
+  frame: OcrFrameKind;
+  key: string;
+  sourceFile: string;
+  textFile: string;
+}
+
+const VISION_HELPER_SOURCE = String.raw`import AppKit
+import Darwin
+import Foundation
+import Vision
+
+struct RecognizedLine {
+    let text: String
+    let bounds: CGRect
+    let originalIndex: Int
+}
+
+func writeStandardError(_ message: String) {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+}
+
+func loadCGImage(at path: String) throws -> CGImage {
+    guard let image = NSImage(contentsOfFile: path) else {
+        throw NSError(
+            domain: "WorkReviewVisionOCR",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "无法解码图片：\(path)"]
+        )
+    }
+
+    var proposedRect = CGRect(origin: .zero, size: image.size)
+    guard let cgImage = image.cgImage(
+        forProposedRect: &proposedRect,
+        context: nil,
+        hints: nil
+    ) else {
+        throw NSError(
+            domain: "WorkReviewVisionOCR",
+            code: 2,
+            userInfo: [NSLocalizedDescriptionKey: "无法创建 CGImage：\(path)"]
+        )
+    }
+    return cgImage
+}
+
+func recognizeText(in imagePath: String) throws -> String {
+    let cgImage = try loadCGImage(at: imagePath)
+    let request = VNRecognizeTextRequest()
+    request.recognitionLevel = .accurate
+    request.usesLanguageCorrection = true
+    request.recognitionLanguages = ["zh-Hans", "en-US"]
+
+    let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+    try handler.perform([request])
+
+    let lines = (request.results ?? []).enumerated().compactMap { item -> RecognizedLine? in
+        guard let candidate = item.element.topCandidates(1).first else { return nil }
+        return RecognizedLine(
+            text: candidate.string,
+            bounds: item.element.boundingBox,
+            originalIndex: item.offset
+        )
+    }.sorted { lhs, rhs in
+        let verticalDifference = abs(lhs.bounds.midY - rhs.bounds.midY)
+        if verticalDifference > 0.01 {
+            return lhs.bounds.midY > rhs.bounds.midY
+        }
+        let horizontalDifference = abs(lhs.bounds.minX - rhs.bounds.minX)
+        if horizontalDifference > 0.01 {
+            return lhs.bounds.minX < rhs.bounds.minX
+        }
+        return lhs.originalIndex < rhs.originalIndex
+    }
+
+    return lines.map(\.text).joined(separator: "\n")
+}
+
+let arguments = Array(CommandLine.arguments.dropFirst())
+if arguments.isEmpty || arguments.count % 2 != 0 {
+    writeStandardError("用法：vision-ocr <图片路径> <输出路径> [<图片路径> <输出路径> ...]")
+    exit(64)
+}
+
+do {
+    for index in stride(from: 0, to: arguments.count, by: 2) {
+        let imagePath = arguments[index]
+        let outputPath = arguments[index + 1]
+        let recognizedText = try recognizeText(in: imagePath)
+        try recognizedText.write(
+            to: URL(fileURLWithPath: outputPath),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+} catch {
+    writeStandardError("Vision OCR 失败：\(error.localizedDescription)")
+    exit(1)
+}
+`;
+
+function buildCanonicalFrames(): CanonicalOcrFrame[] {
+  return OCR_ASPECTS.flatMap((aspect) => STORYBOARD.flatMap((scene) => (
+    OCR_FRAME_KINDS.map((frame) => ({
+      aspect,
+      scene: scene.id,
+      frame,
+      key: `${aspect}/${scene.id}/${frame}`,
+      sourceFile: `${aspect}/${scene.id}-${frame}.png`,
+      textFile: `${aspect}/${scene.id}-${frame}.txt`,
+    }))
+  )));
+}
+
+const CANONICAL_FRAMES = buildCanonicalFrames();
+const CANONICAL_FRAME_BY_KEY = new Map(CANONICAL_FRAMES.map((frame) => [frame.key, frame]));
+
+function frameKey(input: Pick<KeyframeOcrInput, 'aspect' | 'scene' | 'frame'>): string {
+  return `${input.aspect}/${input.scene}/${input.frame}`;
+}
+
+function assertAbsolutePath(value: string, label: string): void {
+  if (!value || !path.isAbsolute(value)) {
+    throw new Error(`${label}必须是绝对路径：${value || '<空>'}`);
+  }
+}
+
+function normalizeOcrText(value: string): string {
+  return value
+    .replace(/\r\n?/gu, '\n')
+    .split('\n')
+    .map((line) => line.trim())
+    .join('\n')
+    .trim();
+}
+
+function formatFailureDetails(result: CommandResult): string {
+  const details = result.stderr.trim() || result.stdout.trim();
+  return details || `退出码 ${result.exitCode}`;
+}
+
+async function assertReadable(filePath: string, message: string): Promise<void> {
+  try {
+    await access(filePath, fsConstants.R_OK);
+  } catch {
+    throw new Error(`${message}：${filePath}`);
+  }
+}
+
+async function assertExecutable(filePath: string, message: string): Promise<void> {
+  try {
+    await access(filePath, fsConstants.X_OK);
+  } catch {
+    throw new Error(`${message}：${filePath}`);
+  }
+}
+
+function validateAndSortInputs(inputs: readonly KeyframeOcrInput[]): KeyframeOcrInput[] {
+  if (!Array.isArray(inputs)) {
+    throw new Error('OCR 关键帧输入必须是数组');
+  }
+
+  const inputByKey = new Map<string, KeyframeOcrInput>();
+  for (const input of inputs) {
+    const key = frameKey(input);
+    if (inputByKey.has(key)) {
+      throw new Error(`存在重复的 OCR 关键帧：${key}`);
+    }
+    if (!CANONICAL_FRAME_BY_KEY.has(key)) {
+      throw new Error(`存在未知的 OCR 关键帧：${key}`);
+    }
+    assertAbsolutePath(input.imagePath, 'OCR 图片路径');
+    inputByKey.set(key, input);
+  }
+
+  const missing = CANONICAL_FRAMES
+    .filter((frame) => !inputByKey.has(frame.key))
+    .map((frame) => frame.key);
+  if (inputs.length !== CANONICAL_FRAMES.length || missing.length > 0) {
+    const suffix = missing.length > 0 ? `，缺少 ${missing.join('、')}` : '';
+    throw new Error(`OCR 输入必须完整包含 42 张关键帧${suffix}`);
+  }
+
+  return CANONICAL_FRAMES.map((frame) => inputByKey.get(frame.key)!);
+}
+
+async function runRequiredCommand(
+  description: string,
+  runner: CommandRunner,
+  binary: string,
+  args: readonly string[],
+): Promise<CommandResult> {
+  let result: CommandResult;
+  try {
+    result = await runner(binary, args);
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    throw new Error(`${description}：${details}`);
+  }
+  if (result.exitCode !== 0) {
+    throw new Error(`${description}：${formatFailureDetails(result)}`);
+  }
+  return result;
+}
+
+/**
+ * 根据 capture.ts 的命名契约构造完整 42 帧输入。
+ */
+export function buildKeyframeOcrInputs(intermediateDir: string): KeyframeOcrInput[] {
+  assertAbsolutePath(intermediateDir, '演示中间目录');
+  return CANONICAL_FRAMES.map((frame) => ({
+    aspect: frame.aspect,
+    scene: frame.scene,
+    frame: frame.frame,
+    imagePath: path.join(intermediateDir, frame.sourceFile),
+  }));
+}
+
+/**
+ * 使用 macOS Vision 对全部演示关键帧执行真实 OCR。
+ *
+ * 所有路径均以独立 argv 传入子进程，绝不经过 shell 拼接。只有 42 张图片均成功
+ * 生成 OCR 文本后才会写入最终清单，任何缺帧、工具或执行错误都会阻断交付。
+ */
+export async function extractKeyframeOcr(
+  options: ExtractKeyframeOcrOptions,
+): Promise<KeyframeOcrResult> {
+  const platform = options.platform ?? process.platform;
+  if (platform !== 'darwin') {
+    throw new Error(`关键帧 OCR 仅支持 macOS Vision，当前平台：${platform}`);
+  }
+
+  assertAbsolutePath(options.outputDir, 'OCR 输出目录');
+  const inputs = validateAndSortInputs(options.inputs);
+  const swiftCompilerPath = options.swiftCompilerPath ?? '/usr/bin/swiftc';
+  assertAbsolutePath(swiftCompilerPath, 'Swift 编译工具路径');
+
+  await assertExecutable(swiftCompilerPath, 'macOS Vision OCR 编译工具不可用');
+  for (const input of inputs) {
+    await assertReadable(input.imagePath, 'OCR 图片不存在或不可读取');
+  }
+
+  const runner = options.runner ?? runCommand;
+  const temporaryDir = await mkdtemp(path.join(tmpdir(), 'work-review-vision-ocr-'));
+  const helperSourcePath = path.join(temporaryDir, 'VisionOcr.swift');
+  const helperPath = path.join(temporaryDir, 'vision-ocr');
+  const rawOutputDir = path.join(temporaryDir, 'raw');
+  const moduleCachePath = path.join(temporaryDir, 'module-cache');
+
+  try {
+    await mkdir(rawOutputDir, { recursive: true });
+    await writeFile(helperSourcePath, VISION_HELPER_SOURCE, 'utf8');
+
+    await runRequiredCommand(
+      '编译 macOS Vision OCR 帮助程序失败',
+      runner,
+      swiftCompilerPath,
+      [
+        helperSourcePath,
+        '-O',
+        '-module-cache-path',
+        moduleCachePath,
+        '-framework',
+        'Vision',
+        '-framework',
+        'AppKit',
+        '-o',
+        helperPath,
+      ],
+    );
+    await assertExecutable(helperPath, '编译 macOS Vision OCR 帮助程序失败，未生成可执行文件');
+
+    const rawOutputPaths = inputs.map((_, index) => (
+      path.join(rawOutputDir, `${String(index).padStart(2, '0')}.txt`)
+    ));
+    const ocrArgs = inputs.flatMap((input, index) => [
+      input.imagePath,
+      rawOutputPaths[index]!,
+    ]);
+    await runRequiredCommand(
+      '执行 macOS Vision OCR 失败',
+      runner,
+      helperPath,
+      ocrArgs,
+    );
+
+    const normalizedTexts: string[] = [];
+    for (const [index, rawOutputPath] of rawOutputPaths.entries()) {
+      let rawText: string;
+      try {
+        rawText = await readFile(rawOutputPath, 'utf8');
+      } catch {
+        const input = inputs[index]!;
+        throw new Error(`OCR 输出缺失：${frameKey(input)}（${rawOutputPath}）`);
+      }
+      normalizedTexts.push(normalizeOcrText(rawText));
+    }
+
+    const textFiles: string[] = [];
+    const entries: KeyframeOcrManifestEntry[] = [];
+    for (const [index, frame] of CANONICAL_FRAMES.entries()) {
+      const outputPath = path.join(options.outputDir, frame.textFile);
+      const normalizedText = normalizedTexts[index]!;
+      await mkdir(path.dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, normalizedText ? `${normalizedText}\n` : '', 'utf8');
+      textFiles.push(outputPath);
+      entries.push({
+        aspect: frame.aspect,
+        scene: frame.scene,
+        frame: frame.frame,
+        sourceFile: frame.sourceFile,
+        textFile: frame.textFile,
+        characterCount: [...normalizedText].length,
+      });
+    }
+
+    const manifest: KeyframeOcrManifest = {
+      schemaVersion: 1,
+      engine: 'macos-vision',
+      recognitionLanguages: [...OCR_RECOGNITION_LANGUAGES],
+      entryCount: entries.length,
+      entries,
+    };
+    const manifestPath = path.join(options.outputDir, OCR_MANIFEST_FILENAME);
+    await mkdir(options.outputDir, { recursive: true });
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+    return {
+      outputDir: options.outputDir,
+      manifestPath,
+      textFiles,
+      manifest,
+    };
+  } finally {
+    await rm(temporaryDir, { recursive: true, force: true });
+  }
+}

--- a/scripts/product-demo/privacy.test.ts
+++ b/scripts/product-demo/privacy.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createDemoFixtures } from './fixtures.ts';
+import {
+  assertNoSensitiveContent,
+  scanDemoObject,
+  scanSensitiveText,
+} from './privacy.ts';
+import { STORYBOARD } from './storyboard.ts';
+
+function rulesOf(text: string): string[] {
+  return scanSensitiveText(text, 'test-input').map((finding) => finding.rule);
+}
+
+test('识别 macOS、Windows 主目录和邮箱', () => {
+  const findings = scanSensitiveText(
+    [
+      '截图位于 /Users/alice/Library/Application Support/Work Review/capture.png',
+      String.raw`日志位于 C:\Users\alice\AppData\Local\Work Review\debug.log`,
+      '联系 alice@example.com 获取演示数据',
+    ].join('\n'),
+    'paths-and-email',
+  );
+
+  assert.deepEqual(
+    new Set(findings.map((finding) => finding.rule)),
+    new Set(['macos-home', 'windows-home', 'email']),
+  );
+  assert.ok(findings.every((finding) => finding.source === 'paths-and-email'));
+});
+
+test('识别 Bearer、API key 和 Cookie，并掩码输出密钥内容', () => {
+  const bearer = 'bearer-secret-1234567890';
+  const apiKey = 'sk-demo-abcdefghijklmnop';
+  const cookie = 'session=private-cookie-value; csrf=private-csrf-value';
+  const findings = scanSensitiveText(
+    [`Authorization: Bearer ${bearer}`, `OPENAI_API_KEY=${apiKey}`, `Cookie: ${cookie}`].join('\n'),
+    'secrets',
+  );
+
+  assert.deepEqual(
+    new Set(findings.map((finding) => finding.rule)),
+    new Set(['bearer-token', 'api-key', 'cookie']),
+  );
+
+  const report = JSON.stringify(findings);
+  assert.doesNotMatch(report, new RegExp(bearer));
+  assert.doesNotMatch(report, new RegExp(apiKey));
+  assert.doesNotMatch(report, /private-cookie-value|private-csrf-value/);
+  assert.match(report, /\*{3,}|…/);
+});
+
+test('识别 github.com、openai.com 和其他非本地 HTTP(S) URL', () => {
+  const findings = scanSensitiveText(
+    [
+      '源码镜像 github.com/example/private-repo',
+      '模型端点 https://api.openai.com/v1/responses',
+      '上传地址 https://uploads.example.org/demo?source=work-review',
+    ].join('\n'),
+    'external-links',
+  );
+
+  assert.ok(findings.some((finding) => finding.rule === 'forbidden-domain' && finding.match.includes('github.com')));
+  assert.ok(findings.some((finding) => finding.rule === 'forbidden-domain' && finding.match.includes('openai.com')));
+  assert.ok(findings.some((finding) => finding.rule === 'external-url' && finding.match.includes('uploads.example.org')));
+});
+
+test('放行安全目录、演示域名、本地地址以及 data/blob URL', () => {
+  const safeText = [
+    '/tmp/work-review-demo/screenshots/timeline.png',
+    'https://docs.example.test/aurora-board/spec',
+    'http://127.0.0.1:5173/timeline',
+    'http://localhost:5173/report',
+    'data:image/png;base64,AAAA',
+    'blob:http://127.0.0.1:5173/7f6f7458-00f3-4ee8-a548-e3652e90beef',
+  ].join('\n');
+
+  assert.deepEqual(scanSensitiveText(safeText, 'allowed-content'), []);
+});
+
+test('识别禁止出现的虚构能力文案', () => {
+  const rules = rulesOf(
+    [
+      '支持多选片段生成日报。',
+      '提供独立 OCR 开关。',
+      '可以关闭所有 AI。',
+      '所有数据永远不会离开本机。',
+    ].join('\n'),
+  );
+
+  assert.equal(rules.filter((rule) => rule === 'forbidden-capability').length, 4);
+});
+
+test('递归扫描对象，并允许已批准的分镜与演示夹具', () => {
+  const nested = scanDemoObject(
+    { export: { metadata: { owner: 'alice@example.com' } } },
+    'nested-demo',
+  );
+  assert.equal(nested.length, 1);
+  assert.equal(nested[0]?.rule, 'email');
+  assert.equal(nested[0]?.source, 'nested-demo.export.metadata.owner');
+
+  const approvedFindings = scanDemoObject(
+    { storyboard: STORYBOARD, fixtures: createDemoFixtures() },
+    'demo-source',
+  );
+  assert.doesNotThrow(() => assertNoSensitiveContent(approvedFindings));
+});
+
+test('门禁报错只包含已掩码的密钥命中', () => {
+  const rawToken = 'token-that-must-never-appear-in-errors';
+  const findings = scanSensitiveText(`Bearer ${rawToken}`, 'assistant-log');
+
+  assert.throws(
+    () => assertNoSensitiveContent(findings),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /assistant-log/);
+      assert.match(error.message, /bearer-token/);
+      assert.doesNotMatch(error.message, new RegExp(rawToken));
+      return true;
+    },
+  );
+});
+
+test('外部 URL 中的密钥参数不会通过 URL 命中泄露', () => {
+  const rawKey = 'url-secret-abcdefghijklmnop';
+  const findings = scanSensitiveText(
+    `请求 https://uploads.example.org/demo?api_key=${rawKey}&mode=preview`,
+    'network-log',
+  );
+
+  const report = JSON.stringify(findings);
+  assert.ok(findings.some((finding) => finding.rule === 'api-key'));
+  assert.ok(findings.some((finding) => finding.rule === 'external-url'));
+  assert.doesNotMatch(report, new RegExp(rawKey));
+  assert.match(report, /api_key=\*{3,}/);
+});

--- a/scripts/product-demo/privacy.ts
+++ b/scripts/product-demo/privacy.ts
@@ -1,0 +1,199 @@
+export interface PrivacyFinding {
+  source: string;
+  rule:
+    | 'macos-home'
+    | 'windows-home'
+    | 'email'
+    | 'bearer-token'
+    | 'api-key'
+    | 'cookie'
+    | 'forbidden-domain'
+    | 'external-url'
+    | 'forbidden-capability';
+  match: string;
+}
+
+type FindingRule = PrivacyFinding['rule'];
+
+type TextRule = {
+  rule: FindingRule;
+  pattern: RegExp;
+  mask?: (match: string) => string;
+};
+
+const ALLOWED_HTTP_HOSTS = new Set(['docs.example.test', '127.0.0.1', 'localhost', '::1']);
+const FORBIDDEN_DOMAINS = ['github.com', 'openai.com'] as const;
+
+const SECRET_MASK = '***';
+
+const TEXT_RULES: readonly TextRule[] = [
+  {
+    rule: 'macos-home',
+    pattern: /\/Users\/[^/\s"'`\\]+(?:\/[^\s"'`<>]*)?/giu,
+  },
+  {
+    rule: 'windows-home',
+    pattern: /[A-Za-z]:\\Users\\[^\\\s"'`]+(?:\\[^\s"'`<>]*)?/giu,
+  },
+  {
+    rule: 'email',
+    pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/giu,
+  },
+  {
+    rule: 'bearer-token',
+    pattern: /\bBearer\s+[A-Z0-9._~+/=-]{8,}/giu,
+    mask: () => `Bearer ${SECRET_MASK}`,
+  },
+  {
+    rule: 'api-key',
+    pattern:
+      /\b(?:OPENAI_API_KEY|API[_ -]?KEY|APIKEY)\b\s*(?:=|:)\s*(?:["']?)[^\s"',;}]{8,}(?:["']?)/giu,
+    mask: (match) => `${match.split(/\s*(?:=|:)\s*/u, 1)[0]}=${SECRET_MASK}`,
+  },
+  {
+    rule: 'cookie',
+    pattern: /\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+/giu,
+    mask: (match) => `${match.slice(0, match.indexOf(':') + 1)} ${SECRET_MASK}`,
+  },
+  {
+    rule: 'forbidden-capability',
+    pattern: /多选片段生成/gu,
+  },
+  {
+    rule: 'forbidden-capability',
+    pattern: /独立\s*OCR\s*开关/giu,
+  },
+  {
+    rule: 'forbidden-capability',
+    pattern: /关闭所有\s*AI/giu,
+  },
+  {
+    rule: 'forbidden-capability',
+    pattern: /所有数据永远不会离开本机/gu,
+  },
+];
+
+function isForbiddenDomain(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/\.$/u, '');
+  return FORBIDDEN_DOMAINS.some(
+    (domain) => normalized === domain || normalized.endsWith(`.${domain}`),
+  );
+}
+
+function normalizeUrlMatch(match: string): string {
+  return match.replace(/[.,;:!?，。；：！？]+$/u, '');
+}
+
+function maskUrlSecrets(match: string): string {
+  return match.replace(
+    /([?&](?:api[_-]?key|apikey|access[_-]?token|token)=)[^&#\s]+/giu,
+    `$1${SECRET_MASK}`,
+  );
+}
+
+function scanHttpUrls(text: string, source: string): PrivacyFinding[] {
+  const findings: PrivacyFinding[] = [];
+  const urlPattern = /https?:\/\/[^\s"'<>（）()[\]{}]+/giu;
+
+  for (const rawMatch of text.matchAll(urlPattern)) {
+    const match = normalizeUrlMatch(rawMatch[0]);
+    let url: URL;
+    try {
+      url = new URL(match);
+    } catch {
+      continue;
+    }
+
+    const hostname = url.hostname.toLowerCase();
+    const safeMatch = maskUrlSecrets(match);
+    if (isForbiddenDomain(hostname)) {
+      findings.push({ source, rule: 'forbidden-domain', match: safeMatch });
+    } else if (!ALLOWED_HTTP_HOSTS.has(hostname)) {
+      findings.push({ source, rule: 'external-url', match: safeMatch });
+    }
+  }
+
+  return findings;
+}
+
+function scanBareForbiddenDomains(text: string, source: string): PrivacyFinding[] {
+  const findings: PrivacyFinding[] = [];
+  const domainPattern = /(?:[a-z0-9-]+\.)*(?:github\.com|openai\.com)\b/giu;
+
+  for (const rawMatch of text.matchAll(domainPattern)) {
+    const index = rawMatch.index ?? 0;
+    const prefix = text.slice(Math.max(0, index - 8), index).toLowerCase();
+    if (/https?:\/\/$/u.test(prefix)) continue;
+    findings.push({ source, rule: 'forbidden-domain', match: rawMatch[0] });
+  }
+
+  return findings;
+}
+
+function uniqueFindings(findings: PrivacyFinding[]): PrivacyFinding[] {
+  const seen = new Set<string>();
+  return findings.filter((finding) => {
+    const key = `${finding.source}\0${finding.rule}\0${finding.match}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function scanSensitiveText(text: string, source: string): PrivacyFinding[] {
+  const findings: PrivacyFinding[] = [];
+
+  for (const { rule, pattern, mask } of TEXT_RULES) {
+    for (const match of text.matchAll(pattern)) {
+      findings.push({
+        source,
+        rule,
+        match: mask ? mask(match[0]) : match[0],
+      });
+    }
+  }
+
+  findings.push(...scanHttpUrls(text, source));
+  findings.push(...scanBareForbiddenDomains(text, source));
+  return uniqueFindings(findings);
+}
+
+function childSource(source: string, key: string | number, isArray: boolean): string {
+  return isArray ? `${source}[${key}]` : `${source}.${key}`;
+}
+
+export function scanDemoObject(value: unknown, source: string): PrivacyFinding[] {
+  const findings: PrivacyFinding[] = [];
+  const visited = new WeakSet<object>();
+
+  function visit(current: unknown, currentSource: string): void {
+    if (typeof current === 'string') {
+      findings.push(...scanSensitiveText(current, currentSource));
+      return;
+    }
+    if (current === null || typeof current !== 'object') return;
+    if (visited.has(current)) return;
+    visited.add(current);
+
+    if (Array.isArray(current)) {
+      current.forEach((item, index) => visit(item, childSource(currentSource, index, true)));
+      return;
+    }
+
+    for (const [key, item] of Object.entries(current)) {
+      visit(item, childSource(currentSource, key, false));
+    }
+  }
+
+  visit(value, source);
+  return uniqueFindings(findings);
+}
+
+export function assertNoSensitiveContent(findings: readonly PrivacyFinding[]): void {
+  if (findings.length === 0) return;
+
+  const details = findings
+    .map((finding) => `- ${finding.source} [${finding.rule}]: ${finding.match}`)
+    .join('\n');
+  throw new Error(`演示内容隐私与产品真实性扫描失败（${findings.length} 项）：\n${details}`);
+}

--- a/scripts/product-demo/shots.test.ts
+++ b/scripts/product-demo/shots.test.ts
@@ -1,0 +1,629 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { Locator, Page } from 'playwright';
+
+import { createDemoFixtures } from './fixtures.ts';
+import {
+  ASSISTANT_STORAGE_KEY,
+  SHOT_RUNNERS,
+  assertAssistantInvokeContract,
+  buildAssistantStorageState,
+  buildShotRouteUrl,
+  type AssistantInvokeObservation,
+} from './shots.ts';
+import { STORYBOARD } from './storyboard.ts';
+import type { StoryboardSceneId } from './types.ts';
+
+interface Interaction {
+  action: string;
+  target: string;
+  value?: unknown;
+}
+
+class FakeLocator {
+  constructor(
+    private readonly owner: FakePage,
+    private readonly target: string,
+  ) {}
+
+  filter(options: { hasText?: string | RegExp }): FakeLocator {
+    return new FakeLocator(this.owner, `${this.target} hasText=${String(options.hasText ?? '')}`);
+  }
+
+  locator(selector: string): FakeLocator {
+    return new FakeLocator(this.owner, `${this.target} >> ${selector}`);
+  }
+
+  getByRole(role: string, options: { name?: string | RegExp; exact?: boolean } = {}): FakeLocator {
+    return new FakeLocator(this.owner, `${this.target} >> role=${role} name=${String(options.name ?? '')}`);
+  }
+
+  getByText(text: string | RegExp, options: { exact?: boolean } = {}): FakeLocator {
+    return new FakeLocator(this.owner, `${this.target} >> text=${String(text)} exact=${String(options.exact ?? false)}`);
+  }
+
+  getByTitle(title: string | RegExp): FakeLocator {
+    return new FakeLocator(this.owner, `${this.target} >> title=${String(title)}`);
+  }
+
+  async waitFor(options: { state?: string } = {}): Promise<void> {
+    this.owner.interactions.push({ action: `wait:${options.state ?? 'visible'}`, target: this.target });
+    if (this.target.includes('.settings-privacy-rule-row')) {
+      const expectedApp = this.target.includes('hasText=Aurora Notes');
+      const expectedLevel = this.target.includes('hasText=仅统计时长');
+      const matches = this.owner.submittedPrivacyRules.some((rule) => (
+        (!expectedApp || rule.appName === 'Aurora Notes')
+        && (!expectedLevel || rule.level === 'anonymized')
+      ));
+      if (!matches) throw new Error('未找到已提交的隐私规则');
+    }
+  }
+
+  async isVisible(): Promise<boolean> {
+    this.owner.interactions.push({ action: 'isVisible', target: this.target });
+    return true;
+  }
+
+  async click(): Promise<void> {
+    this.owner.interactions.push({ action: 'click', target: this.target });
+    if (this.target.includes('启用截图')) this.owner.screenshotsEnabled = !this.owner.screenshotsEnabled;
+    if (this.target.includes('role=radio name=完全记录')) this.owner.selectedPrivacyLevel = 'full';
+    if (this.target.includes('role=radio name=仅统计时长')) this.owner.selectedPrivacyLevel = 'anonymized';
+    if (this.target.includes('role=radio name=完全忽略')) this.owner.selectedPrivacyLevel = 'ignored';
+    if (this.target === 'role=button name=添加规则' && this.owner.privacyAppName) {
+      this.owner.submittedPrivacyRules.push({
+        appName: this.owner.privacyAppName,
+        level: this.owner.selectedPrivacyLevel,
+      });
+    }
+  }
+
+  async hover(): Promise<void> {
+    this.owner.interactions.push({ action: 'hover', target: this.target });
+  }
+
+  async fill(value: string): Promise<void> {
+    this.owner.interactions.push({ action: 'fill', target: this.target, value });
+    if (this.target.includes('#app-name-input')) this.owner.privacyAppName = value;
+  }
+
+  async focus(): Promise<void> {
+    this.owner.interactions.push({ action: 'focus', target: this.target });
+  }
+
+  async press(key: string): Promise<void> {
+    this.owner.interactions.push({ action: 'press', target: this.target, value: key });
+    if (!this.target.includes('选择助手模型')) return;
+    if (key === 'Home') this.owner.selectedAssistantModel = '__basic__';
+    if (key === 'ArrowDown') this.owner.selectedAssistantModel = 'demo-ai';
+  }
+
+  async selectOption(value: string): Promise<string[]> {
+    this.owner.interactions.push({ action: 'selectOption', target: this.target, value });
+    if (this.target.includes('选择助手模型') && (value === '__basic__' || value === 'demo-ai')) {
+      this.owner.selectedAssistantModel = value;
+    }
+    return [value];
+  }
+
+  async inputValue(): Promise<string> {
+    this.owner.interactions.push({ action: 'inputValue', target: this.target });
+    if (this.target.includes('选择助手模型')) return this.owner.selectedAssistantModel;
+    return '';
+  }
+
+  async getAttribute(name: string): Promise<string | null> {
+    this.owner.interactions.push({ action: `getAttribute:${name}`, target: this.target });
+    if (name === 'aria-checked' && this.target.includes('启用截图')) {
+      return String(this.owner.screenshotsEnabled);
+    }
+    if (name === 'aria-checked' && this.target.includes('完全记录')) {
+      return String(this.owner.selectedPrivacyLevel === 'full');
+    }
+    if (name === 'aria-checked' && this.target.includes('仅统计时长')) {
+      return String(this.owner.selectedPrivacyLevel === 'anonymized');
+    }
+    if (name === 'aria-checked' && this.target.includes('完全忽略')) {
+      return String(this.owner.selectedPrivacyLevel === 'ignored');
+    }
+    return null;
+  }
+
+  async count(): Promise<number> {
+    this.owner.interactions.push({ action: 'count', target: this.target });
+    return /role=switch name=.*(OCR|AI)/.test(this.target)
+      ? this.owner.forbiddenPrivacySwitchCount
+      : 1;
+  }
+}
+
+class FakePage {
+  readonly interactions: Interaction[] = [];
+  readonly serializedBrowserFunctions: string[] = [];
+  screenshotsEnabled = true;
+  selectedAssistantModel = '__basic__';
+  selectedPrivacyLevel: 'full' | 'anonymized' | 'ignored' = 'ignored';
+  privacyAppName = '';
+  submittedPrivacyRules: Array<{
+    appName: string;
+    level: 'full' | 'anonymized' | 'ignored';
+  }> = [];
+  currentUrl = 'http://127.0.0.1:5173/#/overview';
+
+  constructor(
+    readonly assistantInvokeLog: AssistantInvokeObservation[],
+    readonly forbiddenPrivacySwitchCount = 0,
+  ) {}
+
+  url(): string {
+    return this.currentUrl;
+  }
+
+  async goto(url: string): Promise<null> {
+    this.currentUrl = url;
+    this.interactions.push({ action: 'goto', target: url });
+    return null;
+  }
+
+  getByRole(role: string, options: { name?: string | RegExp; exact?: boolean } = {}): FakeLocator {
+    return new FakeLocator(this, `role=${role} name=${String(options.name ?? '')}`);
+  }
+
+  getByText(text: string | RegExp, options: { exact?: boolean } = {}): FakeLocator {
+    return new FakeLocator(this, `text=${String(text)} exact=${String(options.exact ?? false)}`);
+  }
+
+  getByTitle(title: string | RegExp): FakeLocator {
+    return new FakeLocator(this, `title=${String(title)}`);
+  }
+
+  locator(selector: string): FakeLocator {
+    return new FakeLocator(this, `selector=${selector}`);
+  }
+
+  async evaluate(pageFunction: unknown, arg?: unknown): Promise<unknown> {
+    this.serializedBrowserFunctions.push(String(pageFunction));
+    this.interactions.push({ action: 'evaluate', target: 'page', value: arg });
+    if (arg === '__WORK_REVIEW_DEMO_SHOT_INVOKES__') return structuredClone(this.assistantInvokeLog);
+    return null;
+  }
+
+  async waitForFunction(pageFunction: unknown): Promise<void> {
+    this.serializedBrowserFunctions.push(String(pageFunction));
+    this.interactions.push({ action: 'waitForFunction', target: 'assistant invoke log' });
+  }
+
+  async waitForTimeout(milliseconds: number): Promise<void> {
+    this.interactions.push({ action: 'waitForTimeout', target: String(milliseconds) });
+  }
+}
+
+function validAssistantLog(): AssistantInvokeObservation[] {
+  const fixtures = createDemoFixtures();
+  const conversationId = fixtures.assistant.conversationId;
+  const firstHistory = [
+    { role: 'user', content: fixtures.assistant.basicQuestion },
+    { role: 'assistant', content: fixtures.assistant.basicAnswer },
+  ];
+  return [
+    { command: 'create_assistant_conversation', args: { title: fixtures.assistant.basicQuestion } },
+    {
+      command: 'chat_work_assistant',
+      args: { question: fixtures.assistant.basicQuestion, history: [], modelConfig: null },
+    },
+    {
+      command: 'append_assistant_message',
+      args: { conversationId, role: 'user', content: fixtures.assistant.basicQuestion },
+    },
+    {
+      command: 'append_assistant_message',
+      args: { conversationId, role: 'assistant', content: fixtures.assistant.basicAnswer },
+    },
+    {
+      command: 'chat_work_assistant',
+      args: {
+        question: fixtures.assistant.aiQuestion,
+        history: firstHistory,
+        modelConfig: fixtures.assistant.modelProfile.model_config,
+      },
+    },
+    {
+      command: 'append_assistant_message',
+      args: { conversationId, role: 'user', content: fixtures.assistant.aiQuestion },
+    },
+    {
+      command: 'append_assistant_message',
+      args: { conversationId, role: 'assistant', content: fixtures.assistant.aiAnswer },
+    },
+  ];
+}
+
+function scene(id: StoryboardSceneId) {
+  const found = STORYBOARD.find((item) => item.id === id);
+  assert.ok(found, `缺少 ${id} 分镜`);
+  return found;
+}
+
+function asPage(page: FakePage): Page {
+  return page as unknown as Page;
+}
+
+function joinedInteractions(page: FakePage): string {
+  return page.interactions
+    .map((item) => {
+      const value = item.value && typeof item.value === 'object'
+        ? JSON.stringify(item.value)
+        : String(item.value ?? '');
+      return `${item.action} ${item.target} ${value}`;
+    })
+    .join('\n');
+}
+
+function interactionIndex(
+  page: FakePage,
+  predicate: (interaction: Interaction) => boolean,
+): number {
+  return page.interactions.findIndex(predicate);
+}
+
+function assertInteractionOrder(
+  page: FakePage,
+  before: (interaction: Interaction) => boolean,
+  after: (interaction: Interaction) => boolean,
+  message: string,
+): void {
+  const beforeIndex = interactionIndex(page, before);
+  const afterIndex = interactionIndex(page, after);
+  assert.ok(beforeIndex >= 0 && afterIndex >= 0 && beforeIndex < afterIndex, message);
+}
+
+test('七个分镜 runner 完整注册且不增加产品不存在的能力', () => {
+  assert.deepEqual(Object.keys(SHOT_RUNNERS), [
+    'hook',
+    'timeline',
+    'report',
+    'assistant',
+    'privacy',
+    'export',
+    'outro',
+  ]);
+});
+
+test('分镜路由保留当前同源地址并使用 hash 路由', () => {
+  assert.equal(
+    buildShotRouteUrl('http://127.0.0.1:5173/#/overview', '/timeline?date=2026-08-12'),
+    'http://127.0.0.1:5173/#/timeline?date=2026-08-12',
+  );
+  assert.throws(() => buildShotRouteUrl('about:blank', '/report'), /HTTP/);
+});
+
+test('助手进入页面前固定为基础模板且保留用户主动选择标记', () => {
+  assert.equal(ASSISTANT_STORAGE_KEY, 'work-review-assistant-state');
+  assert.deepEqual(buildAssistantStorageState(), {
+    messages: [],
+    selectedModelId: '__basic__',
+    hasUserSelectedModel: true,
+    sending: false,
+    sendingRequestId: null,
+    conversationId: null,
+  });
+});
+
+test('助手调用契约要求同一会话、两轮聊天、四次持久化和完整第一轮历史', () => {
+  const fixtures = createDemoFixtures();
+  assert.doesNotThrow(() => assertAssistantInvokeContract(validAssistantLog(), fixtures));
+
+  const broken = validAssistantLog();
+  const secondChat = [...broken].reverse().find((entry) => entry.command === 'chat_work_assistant');
+  assert.ok(secondChat);
+  secondChat.args.history = [];
+  assert.throws(
+    () => assertAssistantInvokeContract(broken, fixtures),
+    /完整历史/,
+  );
+});
+
+test('七镜头使用真实可见语义选择器、锁定包装和可审计动作帧', async () => {
+  const fixtures = createDemoFixtures();
+  const pages = new Map<StoryboardSceneId, FakePage>();
+
+  for (const id of Object.keys(SHOT_RUNNERS) as StoryboardSceneId[]) {
+    const page = new FakePage(validAssistantLog());
+    pages.set(id, page);
+    const context = {
+      page: asPage(page),
+      aspect: '16x9' as const,
+      scene: scene(id),
+      fixtures,
+      captureActionFrame: async () => {
+        page.interactions.push({ action: 'captureActionFrame', target: id });
+      },
+      markContentStart: () => {
+        page.interactions.push({ action: 'markContentStart', target: id });
+      },
+    };
+    await SHOT_RUNNERS[id](context);
+  }
+
+  for (const id of Object.keys(SHOT_RUNNERS) as StoryboardSceneId[]) {
+    assert.equal(
+      pages.get(id)!.interactions.filter((item) => item.action === 'markContentStart').length,
+      1,
+      `${id} 必须且只能标记一次有效成片起点`,
+    );
+  }
+
+  const hookPage = pages.get('hook')!;
+  assertInteractionOrder(
+    hookPage,
+    (item) => item.action === 'wait:visible' && item.target === 'selector=#work-review-demo-hook',
+    (item) => item.action === 'markContentStart',
+    '片头必须在夜间包装层稳定可见后标记成片起点',
+  );
+  assertInteractionOrder(
+    hookPage,
+    (item) => item.action === 'markContentStart',
+    (item) => item.action === 'wait:hidden' && item.target === 'selector=#work-review-demo-hook',
+    '片头必须先标记包装层，再切回产品主界面',
+  );
+
+  const hook = joinedInteractions(pages.get('hook')!);
+  assert.match(hook, /"kind":"hook"/);
+  assert.match(hook, /今天做了什么？/);
+  assert.match(hook, /深色夜间桌面/);
+  assert.match(hook, /空白日报/);
+  assert.match(hook, /输入光标/);
+  assert.match(hook, /selector=#work-review-demo-hook/);
+  assert.match(hook, /wait:hidden selector=#work-review-demo-hook/);
+  assert.match(hook, /role=heading name=日报/);
+  assert.match(hook, /text=今日暂无日报/);
+  assert.match(hook, /role=button name=.*生成今日日报/);
+
+  const timelinePage = pages.get('timeline')!;
+  const timeline = joinedInteractions(timelinePage);
+  assertInteractionOrder(
+    timelinePage,
+    (item) => item.action === 'wait:visible' && item.target.includes('button.timeline-entry'),
+    (item) => item.action === 'markContentStart',
+    '时间线必须在聚合活动就绪后标记成片起点',
+  );
+  assertInteractionOrder(
+    timelinePage,
+    (item) => item.action === 'markContentStart',
+    (item) => item.action === 'click' && item.target.includes('button.timeline-entry'),
+    '时间线必须在打开详情前标记成片起点',
+  );
+  assert.match(timeline, /selector=button\.timeline-entry hasText=Aurora Board · 导出流程/);
+  assert.match(timeline, /role=dialog name=Cursor/);
+  assert.match(timeline, /role=dialog name=Cursor >> text=Aurora Board · 导出流程 exact=true/);
+  assert.doesNotMatch(timeline, /export_report_markdown · Aurora Board/);
+  assert.equal(timelinePage.interactions.filter((item) => item.action === 'captureActionFrame').length, 1);
+  const timelineCapture = timelinePage.interactions.findIndex((item) => item.action === 'captureActionFrame');
+  const timelineClose = timelinePage.interactions.findIndex(
+    (item) => item.action === 'click' && item.target.includes('role=button name=关闭'),
+  );
+  assert.ok(timelineCapture >= 0 && timelineCapture < timelineClose, '时间线动作帧必须在详情弹窗关闭前捕获');
+  assert.match(timeline, /wait:hidden/);
+
+  const reportPage = pages.get('report')!;
+  const report = joinedInteractions(reportPage);
+  assertInteractionOrder(
+    reportPage,
+    (item) => item.action === 'wait:visible' && item.target === 'role=heading name=日报',
+    (item) => item.action === 'markContentStart',
+    '日报必须在页面标题就绪后标记成片起点',
+  );
+  assertInteractionOrder(
+    reportPage,
+    (item) => item.action === 'markContentStart',
+    (item) => item.action === 'isVisible' && item.target.includes('今日暂无日报'),
+    '日报必须在生成或编辑交互前标记成片起点',
+  );
+  assert.match(report, /role=button name=.*生成今日日报/);
+  assert.match(report, /selector=\.report-section hasText=今日概览/);
+  assert.match(report, /title=编辑/);
+  assert.match(report, /role=dialog name=编辑/);
+  assert.match(report, /fill .*textarea .*## 今日概览/);
+  assert.match(report, /fill .*textarea [\s\S]*已显式保存段落/);
+  assert.match(report, /wait:visible role=dialog name=编辑 >> role=button name=保存/);
+  assert.equal(reportPage.interactions.filter((item) => item.action === 'captureActionFrame').length, 1);
+  const reportCapture = reportPage.interactions.findIndex((item) => item.action === 'captureActionFrame');
+  const reportSave = reportPage.interactions.findIndex(
+    (item) => item.action === 'click' && item.target.includes('role=dialog name=编辑 >> role=button name=保存'),
+  );
+  assert.ok(reportCapture >= 0 && reportCapture < reportSave, '日报动作帧必须在编辑弹窗保存前捕获');
+  assert.match(
+    report,
+    /selector=\.report-section hasText=今日概览 hasText=已显式保存段落/,
+  );
+
+  const assistantPage = pages.get('assistant')!;
+  const assistant = joinedInteractions(assistantPage);
+  assertInteractionOrder(
+    assistantPage,
+    (item) => item.action === 'wait:visible' && item.target === 'role=button name=发送消息',
+    (item) => item.action === 'markContentStart',
+    '助手必须在模型、输入框和发送按钮就绪后标记成片起点',
+  );
+  assertInteractionOrder(
+    assistantPage,
+    (item) => item.action === 'markContentStart',
+    (item) => item.action === 'focus' && item.target.includes('选择助手模型'),
+    '助手必须在模型交互前标记成片起点',
+  );
+  assert.match(assistant, /选择助手模型/);
+  assert.match(assistant, /focus role=combobox name=选择助手模型/);
+  assert.match(assistant, /selectOption role=combobox name=选择助手模型 __basic__/);
+  assert.match(assistant, /inputValue role=combobox name=选择助手模型/);
+  assert.match(assistant, /基础模板 · 已选中/);
+  assert.match(assistant, /selectOption role=combobox name=选择助手模型 demo-ai/);
+  assert.match(assistant, /演示 AI · 已选中/);
+  assert.doesNotMatch(assistant, /press role=combobox name=选择助手模型 (Home|ArrowDown|End|Enter)/);
+  assert.match(assistant, /问点什么/);
+  assert.match(assistant, new RegExp(fixtures.assistant.basicQuestion));
+  assert.match(assistant, new RegExp(fixtures.assistant.basicAnswer));
+  assert.match(assistant, new RegExp(fixtures.assistant.aiQuestion));
+  assert.match(assistant, new RegExp(fixtures.assistant.aiAnswer));
+
+  const privacyPage = pages.get('privacy')!;
+  const privacy = joinedInteractions(privacyPage);
+  assertInteractionOrder(
+    privacyPage,
+    (item) => item.action === 'wait:visible' && item.target === 'role=button name=隐私',
+    (item) => item.action === 'markContentStart',
+    '隐私镜头必须在设置导航就绪后标记成片起点',
+  );
+  assertInteractionOrder(
+    privacyPage,
+    (item) => item.action === 'markContentStart',
+    (item) => item.action === 'click' && item.target === 'role=button name=隐私',
+    '隐私镜头必须在打开隐私页前标记成片起点',
+  );
+  assert.match(privacy, /role=button name=隐私/);
+  assert.ok(
+    privacyPage.interactions.some((item) => (
+      item.action === 'click'
+      && item.target === 'role=button name=/^\\+?\\s*添加规则$/'
+    )),
+    '隐私规则编辑器必须使用锚定名称打开，避免与提交按钮混淆',
+  );
+  assert.match(privacy, /fill selector=#app-name-input Aurora Notes/);
+  assert.match(privacy, /role=radiogroup name=记录策略/);
+  assert.match(privacy, /role=radiogroup name=记录策略 >> role=radio name=完全记录/);
+  assert.match(privacy, /role=radiogroup name=记录策略 >> role=radio name=仅统计时长/);
+  assert.match(privacy, /role=radiogroup name=记录策略 >> role=radio name=完全忽略/);
+  const privacyFull = privacyPage.interactions.findIndex(
+    (item) => item.action === 'click' && item.target.includes('role=radio name=完全记录'),
+  );
+  assert.equal(privacyPage.interactions.filter((item) => item.action === 'captureActionFrame').length, 1);
+  const privacyCapture = privacyPage.interactions.findIndex((item) => item.action === 'captureActionFrame');
+  const privacyAnonymized = privacyPage.interactions.findIndex(
+    (item) => item.action === 'click' && item.target.includes('role=radio name=仅统计时长'),
+  );
+  assert.ok(
+    privacyFull >= 0 && privacyFull < privacyCapture && privacyCapture < privacyAnonymized,
+    '隐私镜头必须先真实选择完全记录，展示三档后再切换为仅统计时长',
+  );
+  assert.deepEqual(privacyPage.submittedPrivacyRules, [
+    { appName: 'Aurora Notes', level: 'anonymized' },
+  ]);
+  assert.match(
+    privacy,
+    /wait:visible selector=\.settings-privacy-rule-row hasText=Aurora Notes hasText=仅统计时长/,
+  );
+  assert.match(privacy, /role=button name=存储/);
+  assert.match(privacy, /role=switch name=启用截图/);
+  assert.match(privacy, /getAttribute:aria-checked .*启用截图/);
+  assert.equal(
+    privacyPage.interactions.filter((item) => (
+      item.action === 'click' && item.target.includes('role=switch name=启用截图')
+    )).length,
+    1,
+    '截图开关必须且只能切换一次',
+  );
+  assert.equal(privacyPage.screenshotsEnabled, false, '隐私镜头结束时截图必须保持关闭');
+  const screenshotReads = privacyPage.interactions
+    .map((item, index) => ({ item, index }))
+    .filter(({ item }) => (
+      item.action === 'getAttribute:aria-checked'
+      && item.target.includes('role=switch name=启用截图')
+    ));
+  const screenshotClick = privacyPage.interactions.findIndex((item) => (
+    item.action === 'click' && item.target.includes('role=switch name=启用截图')
+  ));
+  const privacySave = privacyPage.interactions.findIndex((item) => (
+    item.action === 'click' && item.target === 'role=button name=保存设置'
+  ));
+  assert.equal(screenshotReads.length, 2, '截图开关必须在切换前后各读取一次真实状态');
+  assert.ok(
+    screenshotReads[0]!.index < screenshotClick
+      && screenshotClick < screenshotReads[1]!.index
+      && screenshotReads[1]!.index < privacySave,
+    '截图关闭状态必须在保存设置前得到确认',
+  );
+  assert.match(privacy, /role=button name=保存设置/);
+  assert.match(privacy, /text=设置已保存/);
+
+  const exportPage = pages.get('export')!;
+  const exportShot = joinedInteractions(exportPage);
+  assertInteractionOrder(
+    exportPage,
+    (item) => item.action === 'wait:visible' && item.target === 'role=button name=存储',
+    (item) => item.action === 'markContentStart',
+    '导出镜头必须在设置导航就绪后标记成片起点',
+  );
+  assertInteractionOrder(
+    exportPage,
+    (item) => item.action === 'markContentStart',
+    (item) => item.action === 'click' && item.target === 'role=button name=存储',
+    '导出镜头必须在打开存储页前标记成片起点',
+  );
+  assert.ok(
+    exportShot.includes(
+      `text=当前目录 exact=true >> .. >> text=${fixtures.dataDir} exact=true`,
+    ),
+    '数据目录等待必须限定在“当前目录”字段内',
+  );
+  assert.match(exportShot, /role=button name=打开当前目录/);
+  assert.match(exportShot, /role=button name=导出/);
+  assert.match(exportShot, /role=menuitem name=.*导出当日 Markdown/);
+  assert.match(exportShot, new RegExp(fixtures.exportPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+
+  const outroPage = pages.get('outro')!;
+  const outro = joinedInteractions(outroPage);
+  assertInteractionOrder(
+    outroPage,
+    (item) => item.action === 'wait:visible' && item.target === 'selector=#work-review-demo-outro',
+    (item) => item.action === 'markContentStart',
+    '片尾必须在专用包装层稳定可见后标记成片起点',
+  );
+  assert.match(outro, /"kind":"outro"/);
+  assert.match(outro, /Work Review/);
+  assert.match(outro, /回看今天，写下成果。/);
+  assert.match(outro, /用一个真实工作日，找回你的第一份日报。/);
+  assert.match(outro, /活动记录和截图默认保存在本机；外部 AI 与远程存储按配置使用。/);
+  assert.match(outro, /selector=#work-review-demo-outro/);
+
+  for (const id of ['hook', 'assistant', 'export', 'outro'] as const) {
+    assert.equal(
+      pages.get(id)!.interactions.filter((item) => item.action === 'captureActionFrame').length,
+      0,
+      `${id} 不应额外占用关键动作帧回调`,
+    );
+  }
+
+  const all = [...pages.values()].map(joinedInteractions).join('\n');
+  assert.doesNotMatch(all, /Shift|Control|Meta|drag|多选|框选|OCR 开关|关闭所有 AI|迁移目录/);
+
+  const serializedBrowserFunctions = [...pages.values()]
+    .flatMap((page) => page.serializedBrowserFunctions)
+    .join('\n');
+  assert.doesNotMatch(
+    serializedBrowserFunctions,
+    /\b__name\b/,
+    '分镜浏览器回调序列化后不能依赖 tsx/esbuild 的 __name 辅助函数',
+  );
+  assert.match(
+    serializedBrowserFunctions,
+    /layer\.append\(shell\)/,
+    '片头与片尾包装层必须把已构造的可见内容挂载到遮罩层',
+  );
+});
+
+test('隐私镜头发现独立 OCR 或 AI 开关时必须阻断录制', async () => {
+  const fixtures = createDemoFixtures();
+  const page = new FakePage(validAssistantLog(), 1);
+
+  await assert.rejects(
+    SHOT_RUNNERS.privacy({
+      page: asPage(page),
+      aspect: '16x9',
+      scene: scene('privacy'),
+      fixtures,
+      captureActionFrame: async () => undefined,
+      markContentStart: () => undefined,
+    }),
+    /不得伪造独立 OCR 或 AI 开关/,
+  );
+});

--- a/scripts/product-demo/shots.ts
+++ b/scripts/product-demo/shots.ts
@@ -1,0 +1,723 @@
+import assert from 'node:assert/strict';
+
+import type { DemoFixtures, ShotContext, ShotRunner, StoryboardSceneId } from './types.ts';
+
+export const ASSISTANT_STORAGE_KEY = 'work-review-assistant-state';
+const ASSISTANT_INVOKE_READER = '__WORK_REVIEW_DEMO_SHOT_INVOKES__';
+
+export interface AssistantInvokeObservation {
+  command: string;
+  args: Record<string, unknown>;
+}
+
+interface AssistantStorageState {
+  messages: never[];
+  selectedModelId: '__basic__';
+  hasUserSelectedModel: true;
+  sending: false;
+  sendingRequestId: null;
+  conversationId: null;
+}
+
+interface AssistantInvokeExpectation {
+  chats: number;
+  appends: number;
+}
+
+export function buildAssistantStorageState(): AssistantStorageState {
+  return {
+    messages: [],
+    selectedModelId: '__basic__',
+    hasUserSelectedModel: true,
+    sending: false,
+    sendingRequestId: null,
+    conversationId: null,
+  };
+}
+
+export function buildShotRouteUrl(currentUrl: string, route: string): string {
+  let url: URL;
+  try {
+    url = new URL(currentUrl);
+  } catch {
+    throw new Error(`产品演示分镜只能从 HTTP(S) 页面跳转：${currentUrl}`);
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`产品演示分镜只能从 HTTP(S) 页面跳转：${currentUrl}`);
+  }
+  const normalizedRoute = route.startsWith('/') ? route : `/${route}`;
+  url.hash = `#${normalizedRoute}`;
+  return url.href;
+}
+
+function relevantAssistantInvokes(
+  observations: readonly AssistantInvokeObservation[],
+): AssistantInvokeObservation[] {
+  const relevant = new Set([
+    'create_assistant_conversation',
+    'chat_work_assistant',
+    'append_assistant_message',
+  ]);
+  return observations.filter((entry) => relevant.has(entry.command));
+}
+
+function asHistory(value: unknown): Array<{ role?: unknown; content?: unknown }> {
+  return Array.isArray(value)
+    ? value.filter((item): item is { role?: unknown; content?: unknown } => (
+        typeof item === 'object' && item !== null
+      ))
+    : [];
+}
+
+export function assertAssistantInvokeContract(
+  observations: readonly AssistantInvokeObservation[],
+  fixtures: DemoFixtures,
+): void {
+  const relevant = relevantAssistantInvokes(observations);
+  const creates = relevant.filter((entry) => entry.command === 'create_assistant_conversation');
+  const chats = relevant.filter((entry) => entry.command === 'chat_work_assistant');
+  const appends = relevant.filter((entry) => entry.command === 'append_assistant_message');
+
+  assert.equal(creates.length, 1, '助手演示必须且只能创建一次会话');
+  assert.equal(chats.length, 2, '助手演示必须完成基础模板与演示 AI 两轮聊天');
+  assert.equal(appends.length, 4, '助手演示必须持久化两轮 user + assistant 共四条消息');
+
+  assert.equal(chats[0]?.args.question, fixtures.assistant.basicQuestion, '第一轮必须使用基础模板问题');
+  assert.equal(chats[0]?.args.modelConfig, null, '第一轮必须使用基础模板而不是外部 AI');
+  assert.equal(chats[1]?.args.question, fixtures.assistant.aiQuestion, '第二轮必须使用演示 AI 问题');
+  assert.deepEqual(
+    chats[1]?.args.modelConfig,
+    fixtures.assistant.modelProfile.model_config,
+    '第二轮必须使用隔离的演示 AI 配置',
+  );
+
+  const conversationIds = appends.map((entry) => entry.args.conversationId);
+  assert.ok(
+    conversationIds.every((id) => id === fixtures.assistant.conversationId),
+    '两轮助手消息必须写入同一会话',
+  );
+
+  const expectedMessages = [
+    ['user', fixtures.assistant.basicQuestion],
+    ['assistant', fixtures.assistant.basicAnswer],
+    ['user', fixtures.assistant.aiQuestion],
+    ['assistant', fixtures.assistant.aiAnswer],
+  ] as const;
+  for (const [index, [role, content]] of expectedMessages.entries()) {
+    assert.equal(appends[index]?.args.role, role, `第 ${index + 1} 条持久化消息角色错误`);
+    assert.equal(appends[index]?.args.content, content, `第 ${index + 1} 条持久化消息内容不完整`);
+  }
+
+  const secondHistory = asHistory(chats[1]?.args.history);
+  const completeFirstRound = secondHistory.length >= 2
+    && secondHistory[0]?.role === 'user'
+    && secondHistory[0]?.content === fixtures.assistant.basicQuestion
+    && secondHistory[1]?.role === 'assistant'
+    && typeof secondHistory[1]?.content === 'string'
+    && secondHistory[1].content.startsWith(fixtures.assistant.basicAnswer);
+  assert.ok(completeFirstRound, '第二轮演示 AI 请求必须携带第一轮完整历史');
+}
+
+async function waitForInvokeCounts(
+  page: ShotContext['page'],
+  expectation: AssistantInvokeExpectation,
+): Promise<void> {
+  await page.waitForFunction(
+    async ({ readerName, chats, appends }) => {
+      const reader = (window as unknown as Record<string, unknown>)[readerName];
+      if (typeof reader !== 'function') return false;
+      const observations = await (reader as () => Promise<AssistantInvokeObservation[]>)();
+      return observations.filter((entry) => entry.command === 'chat_work_assistant').length >= chats
+        && observations.filter((entry) => entry.command === 'append_assistant_message').length >= appends;
+    },
+    { readerName: ASSISTANT_INVOKE_READER, ...expectation },
+    { timeout: 10_000 },
+  );
+}
+
+async function readAssistantInvokes(page: ShotContext['page']): Promise<AssistantInvokeObservation[]> {
+  const result = await page.evaluate(
+    async (readerName) => {
+      const reader = (window as unknown as Record<string, unknown>)[readerName];
+      if (typeof reader !== 'function') return [];
+      return (reader as () => Promise<AssistantInvokeObservation[]>)();
+    },
+    ASSISTANT_INVOKE_READER,
+  );
+  return Array.isArray(result) ? result as AssistantInvokeObservation[] : [];
+}
+
+type DemoShotContext = ShotContext & {
+  captureActionFrame?: () => Promise<void>;
+  markContentStart?: () => void;
+};
+
+interface DemoPackagingContent {
+  id: 'work-review-demo-hook' | 'work-review-demo-outro';
+  kind: 'hook' | 'outro';
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  callToAction: string;
+  boundary: string;
+  ariaLabel: string;
+}
+
+async function captureActionFrameIfAvailable(context: ShotContext): Promise<void> {
+  const captureActionFrame = (context as DemoShotContext).captureActionFrame;
+  if (captureActionFrame) await captureActionFrame();
+}
+
+function markContentStartIfAvailable(context: ShotContext): void {
+  (context as DemoShotContext).markContentStart?.();
+}
+
+async function showDemoPackaging(
+  page: ShotContext['page'],
+  content: DemoPackagingContent,
+): Promise<void> {
+  await page.evaluate((payload) => {
+    const existing = document.getElementById(payload.id);
+    existing?.remove();
+
+    const styleId = `${payload.id}-style`;
+    document.getElementById(styleId)?.remove();
+    const style = document.createElement('style');
+    style.id = styleId;
+    style.textContent = `
+      #${payload.id} {
+        position: fixed;
+        inset: 0;
+        z-index: 2147483647;
+        overflow: hidden;
+        box-sizing: border-box;
+        display: grid;
+        place-items: center;
+        font-family: Inter, "PingFang SC", "Microsoft YaHei", sans-serif;
+        color: #f8fafc;
+        background:
+          radial-gradient(circle at 18% 14%, rgba(56, 189, 248, 0.20), transparent 34%),
+          radial-gradient(circle at 82% 84%, rgba(129, 140, 248, 0.18), transparent 36%),
+          linear-gradient(145deg, #07111f 0%, #0b1728 48%, #111827 100%);
+      }
+      #${payload.id} * { box-sizing: border-box; }
+      #${payload.id} .wr-demo-shell {
+        position: relative;
+        width: min(88vw, 1260px);
+        min-height: min(78vh, 780px);
+        display: grid;
+        align-content: center;
+        justify-items: center;
+        gap: 24px;
+      }
+      #${payload.id} .wr-demo-window {
+        width: min(82vw, 1080px);
+        overflow: hidden;
+        border: 1px solid rgba(148, 163, 184, 0.28);
+        border-radius: 26px;
+        background: rgba(15, 23, 42, 0.82);
+        box-shadow: 0 40px 100px rgba(0, 0, 0, 0.48);
+        backdrop-filter: blur(20px);
+      }
+      #${payload.id} .wr-demo-window-bar {
+        height: 52px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 22px;
+        color: #94a3b8;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        font-size: 14px;
+        letter-spacing: 0.04em;
+      }
+      #${payload.id} .wr-demo-dots { display: flex; gap: 8px; }
+      #${payload.id} .wr-demo-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 999px;
+        background: #475569;
+      }
+      #${payload.id} .wr-demo-paper {
+        position: relative;
+        width: min(72vw, 850px);
+        min-height: 430px;
+        margin: 56px auto 64px;
+        padding: 58px 64px;
+        border: 1px solid rgba(226, 232, 240, 0.18);
+        border-radius: 18px;
+        background: linear-gradient(160deg, rgba(30, 41, 59, 0.96), rgba(15, 23, 42, 0.94));
+      }
+      #${payload.id} .wr-demo-eyebrow {
+        display: inline-flex;
+        align-items: center;
+        min-height: 30px;
+        padding: 5px 12px;
+        border: 1px solid rgba(125, 211, 252, 0.35);
+        border-radius: 999px;
+        color: #bae6fd;
+        background: rgba(14, 116, 144, 0.18);
+        font-size: 13px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+      }
+      #${payload.id} .wr-demo-title {
+        max-width: 980px;
+        margin: 22px 0 0;
+        font-size: clamp(42px, 5vw, 78px);
+        line-height: 1.08;
+        letter-spacing: -0.035em;
+        text-align: center;
+      }
+      #${payload.id} .wr-demo-hook-title {
+        margin-top: 28px;
+        color: #f8fafc;
+        font-size: clamp(38px, 4.4vw, 66px);
+        line-height: 1.12;
+        letter-spacing: -0.025em;
+      }
+      #${payload.id} .wr-demo-subtitle {
+        max-width: 900px;
+        margin: 0;
+        color: #cbd5e1;
+        font-size: clamp(20px, 2vw, 30px);
+        line-height: 1.55;
+        text-align: center;
+      }
+      #${payload.id} .wr-demo-empty-line {
+        display: flex;
+        align-items: center;
+        height: 76px;
+        margin-top: 42px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.30);
+      }
+      #${payload.id} .wr-demo-caret {
+        width: 3px;
+        height: 38px;
+        border-radius: 999px;
+        background: #38bdf8;
+        box-shadow: 0 0 18px rgba(56, 189, 248, 0.75);
+      }
+      #${payload.id} .wr-demo-logo {
+        width: 112px;
+        height: 112px;
+        display: grid;
+        place-items: center;
+        border: 1px solid rgba(125, 211, 252, 0.42);
+        border-radius: 28px;
+        color: #e0f2fe;
+        background: linear-gradient(145deg, rgba(14, 165, 233, 0.32), rgba(79, 70, 229, 0.34));
+        box-shadow: 0 24px 70px rgba(14, 165, 233, 0.22);
+        font-size: 48px;
+        font-weight: 800;
+        letter-spacing: -0.08em;
+      }
+      #${payload.id} .wr-demo-cta {
+        margin: 4px 0 0;
+        padding: 14px 24px;
+        border-radius: 999px;
+        color: #082f49;
+        background: #e0f2fe;
+        font-size: clamp(17px, 1.5vw, 23px);
+        font-weight: 800;
+        text-align: center;
+      }
+      #${payload.id} .wr-demo-boundary {
+        max-width: 940px;
+        margin: 4px 0 0;
+        color: #94a3b8;
+        font-size: clamp(14px, 1.2vw, 18px);
+        line-height: 1.55;
+        text-align: center;
+      }
+      @media (max-aspect-ratio: 3/4) {
+        #${payload.id} { padding: 7vh 6vw; }
+        #${payload.id} .wr-demo-shell {
+          width: 100%;
+          min-height: 82vh;
+          gap: 30px;
+        }
+        #${payload.id} .wr-demo-window { width: 100%; }
+        #${payload.id} .wr-demo-paper {
+          width: calc(100% - 44px);
+          min-height: 760px;
+          margin: 42px 22px 48px;
+          padding: 72px 44px;
+        }
+        #${payload.id} .wr-demo-title { font-size: clamp(52px, 9vw, 82px); }
+        #${payload.id} .wr-demo-hook-title { font-size: clamp(46px, 8vw, 72px); }
+        #${payload.id} .wr-demo-subtitle { font-size: clamp(25px, 4.2vw, 36px); }
+        #${payload.id} .wr-demo-logo { width: 132px; height: 132px; font-size: 56px; }
+        #${payload.id} .wr-demo-cta { font-size: clamp(21px, 3.5vw, 30px); }
+        #${payload.id} .wr-demo-boundary { font-size: clamp(17px, 2.8vw, 23px); }
+      }
+    `;
+
+    const layer = document.createElement('section');
+    layer.id = payload.id;
+    layer.dataset.demoPackaging = payload.kind;
+    layer.setAttribute('role', 'region');
+    layer.setAttribute('aria-label', payload.ariaLabel);
+
+    const shell = document.createElement('div');
+    shell.className = 'wr-demo-shell';
+
+    if (payload.kind === 'hook') {
+      const windowFrame = document.createElement('div');
+      windowFrame.className = 'wr-demo-window';
+      const windowBar = document.createElement('div');
+      windowBar.className = 'wr-demo-window-bar';
+      const dots = document.createElement('div');
+      dots.className = 'wr-demo-dots';
+      for (let index = 0; index < 3; index += 1) {
+        const dot = document.createElement('span');
+        dot.className = 'wr-demo-dot';
+        dots.append(dot);
+      }
+      const windowTitle = document.createElement('span');
+      windowTitle.textContent = '23:47 · 今日日报';
+      windowBar.append(dots, windowTitle);
+
+      const paper = document.createElement('div');
+      paper.className = 'wr-demo-paper';
+      const eyebrow = document.createElement('span');
+      eyebrow.className = 'wr-demo-eyebrow';
+      eyebrow.textContent = payload.eyebrow;
+      const title = document.createElement('h1');
+      title.className = 'wr-demo-hook-title';
+      title.textContent = payload.title;
+      const subtitle = document.createElement('p');
+      subtitle.className = 'wr-demo-subtitle';
+      subtitle.textContent = payload.subtitle;
+      paper.append(eyebrow, title, subtitle);
+      const emptyLine = document.createElement('div');
+      emptyLine.className = 'wr-demo-empty-line';
+      const caret = document.createElement('span');
+      caret.className = 'wr-demo-caret';
+      caret.setAttribute('aria-label', '输入光标');
+      emptyLine.append(caret);
+      paper.append(emptyLine);
+      windowFrame.append(windowBar, paper);
+      shell.append(windowFrame);
+    } else {
+      const sourceLogo = document.querySelector<HTMLImageElement>('main img[alt="Work Review"]');
+      const logo = sourceLogo
+        ? sourceLogo.cloneNode(true) as HTMLImageElement
+        : document.createElement('div');
+      logo.className = 'wr-demo-logo';
+      logo.setAttribute('role', 'img');
+      logo.setAttribute('aria-label', 'Work Review Logo');
+      if (logo instanceof HTMLImageElement) {
+        logo.removeAttribute('width');
+        logo.removeAttribute('height');
+        logo.style.objectFit = 'contain';
+        logo.style.padding = '16px';
+      } else {
+        logo.textContent = 'W';
+      }
+      const eyebrow = document.createElement('span');
+      eyebrow.className = 'wr-demo-eyebrow';
+      eyebrow.textContent = payload.eyebrow;
+      const title = document.createElement('h1');
+      title.className = 'wr-demo-title';
+      title.textContent = payload.title;
+      const subtitle = document.createElement('p');
+      subtitle.className = 'wr-demo-subtitle';
+      subtitle.textContent = payload.subtitle;
+      const callToAction = document.createElement('p');
+      callToAction.className = 'wr-demo-cta';
+      callToAction.textContent = payload.callToAction;
+      const boundary = document.createElement('p');
+      boundary.className = 'wr-demo-boundary';
+      boundary.textContent = payload.boundary;
+      shell.append(logo, eyebrow, title, subtitle, callToAction, boundary);
+    }
+
+    layer.append(shell);
+    document.head.append(style);
+    document.body.append(layer);
+  }, content);
+  await page.locator(`#${content.id}`).waitFor();
+}
+
+async function hideDemoPackaging(
+  page: ShotContext['page'],
+  id: DemoPackagingContent['id'],
+): Promise<void> {
+  await page.evaluate((targetId) => {
+    document.getElementById(targetId)?.remove();
+    document.getElementById(`${targetId}-style`)?.remove();
+  }, id);
+  await page.locator(`#${id}`).waitFor({ state: 'hidden' });
+}
+
+async function showAssistantModelSelection(
+  page: ShotContext['page'],
+  label: '基础模板 · 已选中' | '演示 AI · 已选中',
+  mode: 'basic' | 'ai',
+): Promise<void> {
+  await page.evaluate(({ text, selectedMode }) => {
+    const id = 'work-review-demo-model-selection';
+    const existing = document.getElementById(id);
+    existing?.remove();
+    const selector = document.querySelector<HTMLSelectElement>('select[aria-label="选择助手模型"]');
+    if (!selector) throw new Error('助手模型选择器不存在');
+    const badge = document.createElement('span');
+    badge.id = id;
+    badge.dataset.selectedModel = selectedMode;
+    badge.setAttribute('role', 'status');
+    badge.textContent = text;
+    Object.assign(badge.style, {
+      display: 'inline-flex',
+      alignItems: 'center',
+      minHeight: '28px',
+      marginLeft: '10px',
+      padding: '4px 10px',
+      border: `1px solid ${selectedMode === 'ai' ? '#818cf8' : '#38bdf8'}`,
+      borderRadius: '999px',
+      color: selectedMode === 'ai' ? '#c7d2fe' : '#bae6fd',
+      background: selectedMode === 'ai' ? 'rgba(79, 70, 229, 0.22)' : 'rgba(14, 116, 144, 0.20)',
+      fontSize: '12px',
+      fontWeight: '700',
+      whiteSpace: 'nowrap',
+    });
+    selector.parentElement?.insertAdjacentElement('afterend', badge);
+    selector.style.outline = `2px solid ${selectedMode === 'ai' ? '#818cf8' : '#38bdf8'}`;
+    selector.style.outlineOffset = '3px';
+  }, { text: label, selectedMode: mode });
+  await page.getByText(label, { exact: true }).waitFor();
+}
+
+async function runHook(context: ShotContext): Promise<void> {
+  const { page } = context;
+  await page.getByRole('heading', { name: '日报', exact: true }).waitFor();
+  await page.getByText('今日暂无日报', { exact: true }).waitFor();
+  await page.getByRole('button', { name: /生成今日日报/ }).waitFor();
+
+  await showDemoPackaging(page, {
+    id: 'work-review-demo-hook',
+    kind: 'hook',
+    eyebrow: '空白日报',
+    title: '今天做了什么？',
+    subtitle: '下班时，你还记得今天到底做了什么吗？',
+    callToAction: '',
+    boundary: '',
+    ariaLabel: '深色夜间桌面、空白日报与输入光标',
+  });
+  markContentStartIfAvailable(context);
+  await page.waitForTimeout(4_500);
+  await hideDemoPackaging(page, 'work-review-demo-hook');
+  await page.waitForTimeout(1_200);
+}
+
+async function runTimeline(context: ShotContext): Promise<void> {
+  const { page, fixtures } = context;
+  const activity = page
+    .locator('button.timeline-entry')
+    .filter({ hasText: 'Aurora Board · 导出流程' });
+  await activity.waitFor();
+  markContentStartIfAvailable(context);
+  await page.waitForTimeout(900);
+  await activity.click();
+
+  const dialog = page.getByRole('dialog', { name: 'Cursor' });
+  await dialog.waitFor();
+  await dialog.getByText(fixtures.activities[0].title, { exact: true }).waitFor();
+  await page.waitForTimeout(700);
+  await captureActionFrameIfAvailable(context);
+  await page.waitForTimeout(1_800);
+  await dialog.getByRole('button', { name: '关闭', exact: true }).click();
+  await dialog.waitFor({ state: 'hidden' });
+  await page.waitForTimeout(700);
+}
+
+async function generateReportIfEmpty(page: ShotContext['page']): Promise<void> {
+  const empty = page.getByText('今日暂无日报', { exact: true });
+  if (await empty.isVisible()) {
+    await page.getByRole('button', { name: /生成今日日报/ }).click();
+    await page.locator('.report-section').filter({ hasText: '今日概览' }).waitFor();
+  }
+}
+
+async function runReport(context: ShotContext): Promise<void> {
+  const { page, fixtures } = context;
+  await page.getByRole('heading', { name: '日报', exact: true }).waitFor();
+  markContentStartIfAvailable(context);
+  await generateReportIfEmpty(page);
+  const section = page.locator('.report-section').filter({ hasText: '今日概览' });
+  await section.waitFor();
+  await page.waitForTimeout(900);
+  await section.hover();
+  await section.getByTitle('编辑').click();
+
+  const dialog = page.getByRole('dialog', { name: '编辑' });
+  await dialog.waitFor();
+  const editor = dialog.locator('textarea');
+  const updatedContent = `## ${fixtures.report.sections[0].title}\n\n`
+    + `${fixtures.report.sections[0].markdown} 已显式保存段落。`;
+  await editor.fill(updatedContent);
+  const save = dialog.getByRole('button', { name: '保存', exact: true });
+  await save.waitFor();
+  await page.waitForTimeout(700);
+  await captureActionFrameIfAvailable(context);
+  await page.waitForTimeout(800);
+  await save.click();
+  await dialog.waitFor({ state: 'hidden' });
+  await page
+    .locator('.report-section')
+    .filter({ hasText: fixtures.report.sections[0].title })
+    .filter({ hasText: '已显式保存段落。' })
+    .waitFor();
+  await page.waitForTimeout(900);
+}
+
+async function chooseAssistantModel(
+  page: ShotContext['page'],
+  modelSelector: ReturnType<ShotContext['page']['getByRole']>,
+  target: '__basic__' | 'demo-ai',
+): Promise<void> {
+  await modelSelector.focus();
+  await modelSelector.click();
+  await page.waitForTimeout(450);
+  await modelSelector.selectOption(target);
+  await page.waitForTimeout(250);
+  assert.equal(await modelSelector.inputValue(), target, `助手模型必须真实选中 ${target}`);
+  await showAssistantModelSelection(
+    page,
+    target === '__basic__' ? '基础模板 · 已选中' : '演示 AI · 已选中',
+    target === '__basic__' ? 'basic' : 'ai',
+  );
+}
+
+async function runAssistant(context: ShotContext): Promise<void> {
+  const { page, scene, fixtures } = context;
+  await page.evaluate(
+    ({ key, state }) => window.localStorage.setItem(key, JSON.stringify(state)),
+    { key: ASSISTANT_STORAGE_KEY, state: buildAssistantStorageState() },
+  );
+  await page.goto(buildShotRouteUrl(page.url(), scene.route), { waitUntil: 'networkidle' });
+
+  const modelSelector = page.getByRole('combobox', { name: '选择助手模型' });
+  const composer = page.getByRole('textbox', { name: /问点什么/ });
+  const send = page.getByRole('button', { name: '发送消息' });
+  await modelSelector.waitFor();
+  await composer.waitFor();
+  await send.waitFor();
+  markContentStartIfAvailable(context);
+  await chooseAssistantModel(page, modelSelector, '__basic__');
+  await page.waitForTimeout(700);
+
+  await composer.fill(fixtures.assistant.basicQuestion);
+  await send.click();
+  await page.getByText(fixtures.assistant.basicAnswer, { exact: true }).waitFor();
+  await waitForInvokeCounts(page, { chats: 1, appends: 2 });
+  await page.waitForTimeout(1_500);
+
+  await chooseAssistantModel(page, modelSelector, 'demo-ai');
+  await page.waitForTimeout(650);
+  await composer.fill(fixtures.assistant.aiQuestion);
+  await send.click();
+  await page.getByText(fixtures.assistant.aiAnswer, { exact: true }).waitFor();
+  await waitForInvokeCounts(page, { chats: 2, appends: 4 });
+  await page.waitForTimeout(1_500);
+
+  assertAssistantInvokeContract(await readAssistantInvokes(page), fixtures);
+}
+
+async function runPrivacy(context: ShotContext): Promise<void> {
+  const { page } = context;
+  const privacyTab = page.getByRole('button', { name: '隐私', exact: true });
+  await privacyTab.waitFor();
+  markContentStartIfAvailable(context);
+  await privacyTab.click();
+  await page.getByRole('button', { name: /^\+?\s*添加规则$/ }).click();
+  await page.locator('#app-name-input').fill('Aurora Notes');
+
+  const strategyGroup = page.getByRole('radiogroup', { name: '记录策略', exact: true });
+  const full = strategyGroup.getByRole('radio', { name: '完全记录', exact: true });
+  const anonymized = strategyGroup.getByRole('radio', { name: '仅统计时长', exact: true });
+  const ignored = strategyGroup.getByRole('radio', { name: '完全忽略', exact: true });
+  await full.waitFor();
+  await anonymized.waitFor();
+  await ignored.waitFor();
+  await full.click();
+  assert.equal(await full.getAttribute('aria-checked'), 'true', '隐私镜头开始时必须选中完全记录');
+  await page.waitForTimeout(700);
+  await captureActionFrameIfAvailable(context);
+  await page.waitForTimeout(400);
+  await anonymized.click();
+  assert.equal(await anonymized.getAttribute('aria-checked'), 'true', '隐私镜头必须选择仅统计时长');
+  await page.getByRole('button', { name: '添加规则', exact: true }).click();
+  await page.locator('.settings-privacy-rule-row')
+    .filter({ hasText: 'Aurora Notes' })
+    .filter({ hasText: '仅统计时长' })
+    .waitFor();
+  await page.waitForTimeout(900);
+
+  await page.getByRole('button', { name: '存储', exact: true }).click();
+  const screenshotSwitch = page.getByRole('switch', { name: '启用截图', exact: true });
+  await screenshotSwitch.waitFor();
+  assert.equal(await screenshotSwitch.getAttribute('aria-checked'), 'true', '隐私镜头开始时截图必须开启');
+  assert.equal(await page.getByRole('switch', { name: /OCR|AI/ }).count(), 0, '不得伪造独立 OCR 或 AI 开关');
+  await page.waitForTimeout(1_000);
+  await screenshotSwitch.click();
+  assert.equal(await screenshotSwitch.getAttribute('aria-checked'), 'false', '隐私镜头必须真实关闭截图');
+  await page.getByRole('button', { name: '保存设置', exact: true }).click();
+  await page.getByText('设置已保存', { exact: true }).waitFor();
+  await page.waitForTimeout(1_200);
+}
+
+async function runExport(context: ShotContext): Promise<void> {
+  const { page, fixtures } = context;
+  const storageTab = page.getByRole('button', { name: '存储', exact: true });
+  await storageTab.waitFor();
+  markContentStartIfAvailable(context);
+  await storageTab.click();
+  const currentDataDir = page
+    .getByText('当前目录', { exact: true })
+    .locator('..')
+    .getByText(fixtures.dataDir, { exact: true });
+  await currentDataDir.waitFor();
+  await page.getByRole('button', { name: '打开当前目录', exact: true }).click();
+  await page.waitForTimeout(900);
+
+  await page.getByRole('link', { name: '日报', exact: true }).click();
+  await page.getByRole('heading', { name: '日报', exact: true }).waitFor();
+  await generateReportIfEmpty(page);
+  await page.waitForTimeout(900);
+  await page.getByRole('button', { name: '导出', exact: true }).click();
+  await page.getByRole('menuitem', { name: /导出当日 Markdown/ }).click();
+  await page.getByText(
+    `日报已导出到 ${fixtures.exportPath}`,
+    { exact: true },
+  ).waitFor();
+  await page.waitForTimeout(1_200);
+}
+
+async function runOutro(context: ShotContext): Promise<void> {
+  const { page } = context;
+  const main = page.getByRole('main');
+  await main.getByRole('heading', { name: 'Work Review', exact: true }).waitFor();
+  await main.getByRole('img', { name: 'Work Review', exact: true }).waitFor();
+  await showDemoPackaging(page, {
+    id: 'work-review-demo-outro',
+    kind: 'outro',
+    eyebrow: 'WORK REVIEW',
+    title: 'Work Review',
+    subtitle: '回看今天，写下成果。',
+    callToAction: '用一个真实工作日，找回你的第一份日报。',
+    boundary: '活动记录和截图默认保存在本机；外部 AI 与远程存储按配置使用。',
+    ariaLabel: 'Work Review 产品片尾',
+  });
+  markContentStartIfAvailable(context);
+  await page.waitForTimeout(1_200);
+}
+
+export const SHOT_RUNNERS: Record<StoryboardSceneId, ShotRunner> = {
+  hook: runHook,
+  timeline: runTimeline,
+  report: runReport,
+  assistant: runAssistant,
+  privacy: runPrivacy,
+  export: runExport,
+  outro: runOutro,
+};

--- a/scripts/product-demo/storyboard.test.ts
+++ b/scripts/product-demo/storyboard.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  DEMO_DURATION_SECONDS,
+  DEMO_FPS,
+  DEMO_TOTAL_FRAMES,
+  STORYBOARD,
+  VOICEOVER_CUES,
+  validateStoryboard,
+} from './storyboard.ts';
+
+test('分镜固定为 85 秒、30fps 和 2550 帧', () => {
+  assert.equal(DEMO_DURATION_SECONDS, 85);
+  assert.equal(DEMO_FPS, 30);
+  assert.equal(DEMO_TOTAL_FRAMES, 2550);
+  assert.equal(STORYBOARD.length, 7);
+  assert.deepEqual(STORYBOARD.map(({ start, end }) => [start, end]), [
+    [0, 7],
+    [7, 19],
+    [19, 32],
+    [32, 51],
+    [51, 68],
+    [68, 78],
+    [78, 85],
+  ]);
+  assert.doesNotThrow(validateStoryboard);
+});
+
+test('每个分镜都有横竖屏独立构图', () => {
+  for (const scene of STORYBOARD) {
+    assert.ok(scene.composition['16x9']);
+    assert.ok(scene.composition['9x16']);
+    assert.notDeepEqual(scene.composition['16x9'], scene.composition['9x16']);
+  }
+});
+
+test('助手只包含基础模板和演示 AI 两个阶段', () => {
+  const assistant = STORYBOARD.find((scene) => scene.id === 'assistant');
+  assert.ok(assistant);
+  assert.deepEqual(assistant.assistantStages, ['basic-template', 'demo-ai']);
+  assert.equal(VOICEOVER_CUES.length, 7);
+});

--- a/scripts/product-demo/storyboard.test.ts
+++ b/scripts/product-demo/storyboard.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { DEMO_RECORDING_CONFIG } from './browser.ts';
 import {
   DEMO_DURATION_SECONDS,
   DEMO_FPS,
@@ -40,4 +41,36 @@ test('助手只包含基础模板和演示 AI 两个阶段', () => {
   assert.ok(assistant);
   assert.deepEqual(assistant.assistantStages, ['basic-template', 'demo-ai']);
   assert.equal(VOICEOVER_CUES.length, 7);
+});
+
+test('导出旁白保留准确数据边界并控制在 Tingting 可用时长内', () => {
+  const cue = VOICEOVER_CUES.find((item) => item.id === 'export');
+  assert.ok(cue);
+  assert.match(cue.zh, /活动记录.*截图.*默认.*本机/u);
+  assert.match(cue.zh, /Markdown/u);
+  assert.match(cue.zh, /外部 AI.*远程存储.*按配置使用/u);
+  assert.ok([...cue.zh].length <= 44, `导出旁白过长：${[...cue.zh].length} 字`);
+});
+
+
+test('浏览器录制配置固定横竖屏视口、语言、时区和动效偏好', () => {
+  assert.deepEqual(DEMO_RECORDING_CONFIG['16x9'], {
+    viewport: { width: 1920, height: 1080 },
+    videoSize: { width: 1920, height: 1080 },
+    deviceScaleFactor: 1,
+    locale: 'zh-CN',
+    timezoneId: 'Asia/Shanghai',
+    reducedMotion: 'reduce',
+  });
+  assert.deepEqual(DEMO_RECORDING_CONFIG['9x16'], {
+    viewport: { width: 1080, height: 1920 },
+    videoSize: { width: 1080, height: 1920 },
+    deviceScaleFactor: 1,
+    locale: 'zh-CN',
+    timezoneId: 'Asia/Shanghai',
+    reducedMotion: 'reduce',
+  });
+  for (const scene of STORYBOARD) {
+    assert.ok(scene.composition['9x16'], `${scene.id} 缺少竖屏独立构图`);
+  }
 });

--- a/scripts/product-demo/storyboard.ts
+++ b/scripts/product-demo/storyboard.ts
@@ -1,0 +1,137 @@
+import type { StoryboardCue, StoryboardScene } from './types.ts';
+
+export const DEMO_DATE = '2026-08-12';
+export const DEMO_TIMEZONE = 'Asia/Shanghai';
+export const DEMO_FPS = 30;
+export const DEMO_DURATION_SECONDS = 85;
+export const DEMO_TOTAL_FRAMES = DEMO_DURATION_SECONDS * DEMO_FPS;
+
+export const STORYBOARD: readonly StoryboardScene[] = [
+  {
+    id: 'hook',
+    start: 0,
+    end: 7,
+    route: '/report',
+    voiceoverZh: '下班时，你还记得今天到底做了什么吗？',
+    subtitleEn: 'At the end of the day, can you still remember what you actually worked on?',
+    composition: {
+      '16x9': { crop: '1920:1080:0:0', scale: '1920:1080', focus: '日报空态与问题标题' },
+      '9x16': { crop: '900:1600:510:0', scale: '1080:1920', focus: '日报空态中央区域' },
+    },
+  },
+  {
+    id: 'timeline',
+    start: 7,
+    end: 19,
+    route: '/timeline?date=2026-08-12',
+    voiceoverZh: 'Work-Review 把当天用过的应用、页面和时间整理成一条可回看的工作轨迹。',
+    subtitleEn: 'Work-Review turns the apps, pages, and time from your day into a timeline you can revisit.',
+    composition: {
+      '16x9': { crop: '1920:1080:0:0', scale: '1920:1080', focus: '时间线与活动详情抽屉' },
+      '9x16': { crop: '760:1350:930:0', scale: '1080:1920', focus: '右侧时间线与详情抽屉' },
+    },
+  },
+  {
+    id: 'report',
+    start: 19,
+    end: 32,
+    route: '/report',
+    voiceoverZh: '选择日期，就能根据整日记录生成日报草稿；每个段落都可以再由我修改和保存。',
+    subtitleEn: 'Choose a date to draft a report from the full day’s records, then edit and save each section yourself.',
+    composition: {
+      '16x9': { crop: '1920:1080:0:0', scale: '1920:1080', focus: '生成按钮、日报正文与段落编辑弹窗' },
+      '9x16': { crop: '860:1528:600:0', scale: '1080:1920', focus: '日报正文和编辑弹窗' },
+    },
+  },
+  {
+    id: 'assistant',
+    start: 32,
+    end: 51,
+    route: '/ask',
+    voiceoverZh: '先用基础模板查看今天的时长、分类和常用应用；保持同一对话，切换到配置好的 AI，再查今日记录，提炼一项有依据的成果。',
+    subtitleEn: 'Start with the basic template for time, categories, and top apps. In the same conversation, switch to your configured AI and turn today’s records into an evidence-based outcome.',
+    composition: {
+      '16x9': { crop: '1920:1080:0:0', scale: '1920:1080', focus: '模型选择器与对话内容' },
+      '9x16': { crop: '850:1511:820:0', scale: '1080:1920', focus: '模型选择器、输入框与消息流' },
+    },
+    assistantStages: ['basic-template', 'demo-ai'],
+  },
+  {
+    id: 'privacy',
+    start: 51,
+    end: 68,
+    route: '/settings',
+    voiceoverZh: '它不是监控软件。每个应用可以完全记录、只统计时长或完全忽略；关闭截图后，截图和 OCR 也会停止。',
+    subtitleEn: 'It is not monitoring software. Each app can be fully recorded, time-only, or ignored; turn off screenshots and both screenshots and OCR stop.',
+    composition: {
+      '16x9': { crop: '1920:1080:0:0', scale: '1920:1080', focus: '隐私三档与截图开关' },
+      '9x16': { crop: '900:1600:690:0', scale: '1080:1920', focus: '设置内容区域' },
+    },
+  },
+  {
+    id: 'export',
+    start: 68,
+    end: 78,
+    route: '/settings',
+    voiceoverZh: '活动记录和截图默认保存在本机；目录可以查看，日报也能导出为 Markdown。外部 AI 与远程存储按配置使用。',
+    subtitleEn: 'Activity records and screenshots stay on your device by default. Inspect the folder and export reports as Markdown; external AI and remote storage follow your configuration.',
+    composition: {
+      '16x9': { crop: '1920:1080:0:0', scale: '1920:1080', focus: '本地数据目录与导出成功提示' },
+      '9x16': { crop: '900:1600:650:0', scale: '1080:1920', focus: '目录路径与导出反馈' },
+    },
+  },
+  {
+    id: 'outro',
+    start: 78,
+    end: 85,
+    route: '/about',
+    voiceoverZh: '用一个真实工作日，找回你的第一份日报。',
+    subtitleEn: 'Try it with one real workday and rediscover your first report.',
+    composition: {
+      '16x9': { crop: '1920:1080:0:0', scale: '1920:1080', focus: 'Logo 与片尾文案' },
+      '9x16': { crop: '900:1600:510:0', scale: '1080:1920', focus: '竖屏 Logo 与片尾文案' },
+    },
+  },
+] as const;
+
+export const VOICEOVER_CUES: readonly StoryboardCue[] = STORYBOARD.map((scene) => ({
+  id: scene.id,
+  start: scene.start + 0.35,
+  end: scene.end - 0.35,
+  zh: scene.voiceoverZh,
+  en: scene.subtitleEn,
+}));
+
+export function validateStoryboard(): void {
+  if (STORYBOARD.length !== 7) throw new Error('演示视频必须包含七个分镜');
+  if (STORYBOARD[0]?.start !== 0) throw new Error('首个分镜必须从 0 秒开始');
+  if (STORYBOARD.at(-1)?.end !== DEMO_DURATION_SECONDS) {
+    throw new Error('末个分镜必须在 85 秒结束');
+  }
+
+  for (const [index, scene] of STORYBOARD.entries()) {
+    if (scene.end <= scene.start) throw new Error(`分镜 ${scene.id} 时长无效`);
+    if (!Number.isInteger(scene.start * DEMO_FPS) || !Number.isInteger(scene.end * DEMO_FPS)) {
+      throw new Error(`分镜 ${scene.id} 未对齐整数帧`);
+    }
+    if (!scene.composition['16x9'] || !scene.composition['9x16']) {
+      throw new Error(`分镜 ${scene.id} 缺少横屏或竖屏构图`);
+    }
+    const previous = STORYBOARD[index - 1];
+    if (previous && previous.end !== scene.start) {
+      throw new Error(`分镜 ${previous.id} 与 ${scene.id} 不连续`);
+    }
+  }
+
+  const assistant = STORYBOARD.find((scene) => scene.id === 'assistant');
+  if (!assistant || assistant.assistantStages?.join(',') !== 'basic-template,demo-ai') {
+    throw new Error('助手分镜必须依次展示基础模板和演示 AI');
+  }
+
+  if (VOICEOVER_CUES.some((cue, index) => cue.start < 0
+    || cue.end > DEMO_DURATION_SECONDS
+    || cue.end <= cue.start
+    || (index > 0 && cue.start < VOICEOVER_CUES[index - 1].end))) {
+    throw new Error('旁白时间轴越界或重叠');
+  }
+}

--- a/scripts/product-demo/storyboard.ts
+++ b/scripts/product-demo/storyboard.ts
@@ -73,7 +73,7 @@ export const STORYBOARD: readonly StoryboardScene[] = [
     start: 68,
     end: 78,
     route: '/settings',
-    voiceoverZh: '活动记录和截图默认保存在本机；目录可以查看，日报也能导出为 Markdown。外部 AI 与远程存储按配置使用。',
+    voiceoverZh: '活动记录和截图默认本机；查目录、导出 Markdown；外部 AI、远程存储按配置使用。',
     subtitleEn: 'Activity records and screenshots stay on your device by default. Inspect the folder and export reports as Markdown; external AI and remote storage follow your configuration.',
     composition: {
       '16x9': { crop: '1920:1080:0:0', scale: '1920:1080', focus: '本地数据目录与导出成功提示' },

--- a/scripts/product-demo/subtitles.test.ts
+++ b/scripts/product-demo/subtitles.test.ts
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { DEMO_DURATION_SECONDS, VOICEOVER_CUES } from './storyboard.ts';
+import {
+  buildBilingualSrt,
+  buildSrt,
+  buildSubtitleOverlayHtml,
+  formatSrtTimestamp,
+  validateSubtitleTimeline,
+  writeSubtitleArtifacts,
+} from './subtitles.ts';
+import type { StoryboardCue } from './types.ts';
+
+interface ParsedSrtEntry {
+  index: number;
+  start: string;
+  end: string;
+  lines: string[];
+}
+
+function parseSrt(content: string): ParsedSrtEntry[] {
+  return content
+    .trim()
+    .split(/\r?\n\r?\n/)
+    .map((block) => {
+      const [indexLine, timeLine, ...lines] = block.split(/\r?\n/);
+      assert.ok(indexLine);
+      assert.ok(timeLine);
+      const [start, end] = timeLine.split(' --> ');
+      assert.ok(start);
+      assert.ok(end);
+      return { index: Number(indexLine), start, end, lines };
+    });
+}
+
+test('将秒数格式化为标准 SRT 时间戳', () => {
+  assert.equal(formatSrtTimestamp(0), '00:00:00,000');
+  assert.equal(formatSrtTimestamp(7.04), '00:00:07,040');
+  assert.equal(formatSrtTimestamp(65.004), '00:01:05,004');
+  assert.equal(formatSrtTimestamp(3599.9996), '01:00:00,000');
+  assert.throws(() => formatSrtTimestamp(-0.001), /非负有限数/);
+  assert.throws(() => formatSrtTimestamp(Number.NaN), /非负有限数/);
+});
+
+test('生成数量与时间轴一致的中文和英文 SRT', () => {
+  const zhEntries = parseSrt(buildSrt(VOICEOVER_CUES, 'zh'));
+  const enEntries = parseSrt(buildSrt(VOICEOVER_CUES, 'en'));
+
+  assert.equal(zhEntries.length, VOICEOVER_CUES.length);
+  assert.equal(enEntries.length, VOICEOVER_CUES.length);
+  assert.deepEqual(
+    zhEntries.map(({ index, start, end }) => ({ index, start, end })),
+    enEntries.map(({ index, start, end }) => ({ index, start, end })),
+  );
+  assert.match(zhEntries[0]?.lines.join('\n') ?? '', /下班时/);
+  assert.match(enEntries[0]?.lines.join('\n') ?? '', /At the end of the day/);
+});
+
+test('双语 SRT 每条均为中文在上、英文在下', () => {
+  const entries = parseSrt(buildBilingualSrt(VOICEOVER_CUES));
+
+  assert.equal(entries.length, VOICEOVER_CUES.length);
+  entries.forEach((entry, index) => {
+    assert.deepEqual(entry.lines, [VOICEOVER_CUES[index]?.zh, VOICEOVER_CUES[index]?.en]);
+  });
+  assert.match(buildBilingualSrt(VOICEOVER_CUES), /下班时[\s\S]*At the end of the day/);
+});
+
+test('校验字幕时间轴单调、不重叠且不超过视频时长', () => {
+  assert.doesNotThrow(() => validateSubtitleTimeline(VOICEOVER_CUES, DEMO_DURATION_SECONDS));
+
+  const invalidCases: Array<{ cue: StoryboardCue[]; message: RegExp }> = [
+    {
+      cue: [{ id: 'negative', start: -0.1, end: 1, zh: '中', en: 'en' }],
+      message: /不得早于 0 秒/,
+    },
+    {
+      cue: [{ id: 'empty', start: 1, end: 1, zh: '中', en: 'en' }],
+      message: /结束时间必须晚于开始时间/,
+    },
+    {
+      cue: [{ id: 'late', start: 84, end: 85.1, zh: '中', en: 'en' }],
+      message: /超过视频时长/,
+    },
+    {
+      cue: [
+        { id: 'first', start: 1, end: 3, zh: '中一', en: 'one' },
+        { id: 'second', start: 2.9, end: 4, zh: '中二', en: 'two' },
+      ],
+      message: /与上一条重叠/,
+    },
+  ];
+
+  for (const invalid of invalidCases) {
+    assert.throws(
+      () => validateSubtitleTimeline(invalid.cue, DEMO_DURATION_SECONDS),
+      invalid.message,
+    );
+  }
+});
+
+test('横竖屏字幕层使用透明背景、系统字体和不同安全边距', () => {
+  const cue = VOICEOVER_CUES[0];
+  assert.ok(cue);
+
+  const landscape = buildSubtitleOverlayHtml(cue, '16x9');
+  const portrait = buildSubtitleOverlayHtml(cue, '9x16');
+
+  for (const html of [landscape, portrait]) {
+    assert.match(html, /background:\s*transparent/);
+    assert.match(html, /-apple-system/);
+    assert.match(html, /"PingFang SC"/);
+    assert.match(html, /"Microsoft YaHei"/);
+    assert.match(html, /text-shadow:/);
+    assert.ok(html.indexOf(cue.zh) < html.indexOf(cue.en));
+  }
+
+  assert.match(landscape, /--subtitle-safe-bottom:\s*84px/);
+  assert.match(landscape, /\.subtitle-zh\s*\{[^}]*font-size:\s*54px/s);
+  assert.match(landscape, /\.subtitle-en\s*\{[^}]*font-size:\s*32px/s);
+
+  assert.match(portrait, /--subtitle-safe-bottom:\s*240px/);
+  assert.match(portrait, /\.subtitle-zh\s*\{[^}]*font-size:\s*50px/s);
+  assert.match(portrait, /\.subtitle-en\s*\{[^}]*font-size:\s*30px/s);
+});
+
+test('字幕层转义文本，避免字幕内容破坏 HTML', () => {
+  const html = buildSubtitleOverlayHtml(
+    {
+      id: 'escape',
+      start: 0,
+      end: 1,
+      zh: '<中文 & 字幕>',
+      en: '"English" <script>',
+    },
+    '16x9',
+  );
+
+  assert.match(html, /&lt;中文 &amp; 字幕&gt;/);
+  assert.match(html, /&quot;English&quot; &lt;script&gt;/);
+  assert.doesNotMatch(html, /<script>/);
+});
+
+test('写出中文、英文和双语三个 UTF-8 SRT 文件', async () => {
+  const outputDir = await mkdtemp(join(tmpdir(), 'work-review-subtitles-'));
+  const paths = await writeSubtitleArtifacts(outputDir, VOICEOVER_CUES);
+
+  assert.deepEqual(Object.keys(paths).sort(), ['bilingual', 'en', 'zh']);
+  assert.match(await readFile(paths.zh, 'utf8'), /下班时/);
+  assert.match(await readFile(paths.en, 'utf8'), /At the end of the day/);
+  assert.match(await readFile(paths.bilingual, 'utf8'), /下班时[\s\S]*At the end of the day/);
+});

--- a/scripts/product-demo/subtitles.ts
+++ b/scripts/product-demo/subtitles.ts
@@ -1,0 +1,240 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { DEMO_DURATION_SECONDS, VOICEOVER_CUES } from './storyboard.ts';
+import type { DemoAspect, StoryboardCue } from './types.ts';
+
+export type SubtitleLanguage = 'zh' | 'en';
+
+export interface SubtitleArtifactPaths {
+  zh: string;
+  en: string;
+  bilingual: string;
+}
+
+const SYSTEM_FONT_STACK = [
+  '-apple-system',
+  'BlinkMacSystemFont',
+  '"SF Pro Text"',
+  '"PingFang SC"',
+  '"Hiragino Sans GB"',
+  '"Segoe UI"',
+  '"Microsoft YaHei"',
+  'sans-serif',
+].join(', ');
+
+const OVERLAY_LAYOUT: Record<DemoAspect, {
+  width: number;
+  height: number;
+  safeBottom: number;
+  horizontalPadding: number;
+  zhFontSize: number;
+  enFontSize: number;
+}> = {
+  '16x9': {
+    width: 1920,
+    height: 1080,
+    safeBottom: 84,
+    horizontalPadding: 120,
+    zhFontSize: 54,
+    enFontSize: 32,
+  },
+  '9x16': {
+    width: 1080,
+    height: 1920,
+    safeBottom: 240,
+    horizontalPadding: 72,
+    zhFontSize: 50,
+    enFontSize: 30,
+  },
+};
+
+export function formatSrtTimestamp(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    throw new TypeError('SRT 时间必须是非负有限数');
+  }
+
+  const totalMilliseconds = Math.round(seconds * 1000);
+  const milliseconds = totalMilliseconds % 1000;
+  const totalSeconds = Math.floor(totalMilliseconds / 1000);
+  const secs = totalSeconds % 60;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const minutes = totalMinutes % 60;
+  const hours = Math.floor(totalMinutes / 60);
+
+  return [
+    String(hours).padStart(2, '0'),
+    String(minutes).padStart(2, '0'),
+    `${String(secs).padStart(2, '0')},${String(milliseconds).padStart(3, '0')}`,
+  ].join(':');
+}
+
+export function validateSubtitleTimeline(
+  cues: readonly StoryboardCue[],
+  durationSeconds = DEMO_DURATION_SECONDS,
+): void {
+  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+    throw new TypeError('视频时长必须是正有限数');
+  }
+
+  for (const [index, cue] of cues.entries()) {
+    if (!Number.isFinite(cue.start) || !Number.isFinite(cue.end)) {
+      throw new Error(`字幕 ${cue.id} 的时间必须是有限数`);
+    }
+    if (cue.start < 0) {
+      throw new Error(`字幕 ${cue.id} 不得早于 0 秒`);
+    }
+    if (cue.end <= cue.start) {
+      throw new Error(`字幕 ${cue.id} 的结束时间必须晚于开始时间`);
+    }
+    if (cue.end > durationSeconds) {
+      throw new Error(`字幕 ${cue.id} 超过视频时长`);
+    }
+
+    const previous = cues[index - 1];
+    if (previous && cue.start < previous.end) {
+      throw new Error(`字幕 ${cue.id} 与上一条重叠`);
+    }
+  }
+}
+
+export function buildSrt(
+  cues: readonly StoryboardCue[],
+  language: SubtitleLanguage,
+): string {
+  validateSubtitleTimeline(cues);
+  return buildSrtFromLines(cues, (cue) => [cue[language]]);
+}
+
+export function buildBilingualSrt(cues: readonly StoryboardCue[]): string {
+  validateSubtitleTimeline(cues);
+  return buildSrtFromLines(cues, (cue) => [cue.zh, cue.en]);
+}
+
+export function buildSubtitleOverlayHtml(cue: StoryboardCue, aspect: DemoAspect): string {
+  const layout = OVERLAY_LAYOUT[aspect];
+  const zh = escapeHtml(cue.zh);
+  const en = escapeHtml(cue.en);
+
+  return `<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root {
+      --subtitle-safe-bottom: ${layout.safeBottom}px;
+      --subtitle-horizontal-padding: ${layout.horizontalPadding}px;
+    }
+
+    * { box-sizing: border-box; }
+
+    html,
+    body {
+      width: ${layout.width}px;
+      height: ${layout.height}px;
+      margin: 0;
+      overflow: hidden;
+      background: transparent;
+    }
+
+    body {
+      color: #fff;
+      font-family: ${SYSTEM_FONT_STACK};
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .subtitle-stage {
+      position: absolute;
+      right: var(--subtitle-horizontal-padding);
+      bottom: var(--subtitle-safe-bottom);
+      left: var(--subtitle-horizontal-padding);
+      display: flex;
+      justify-content: center;
+      text-align: center;
+    }
+
+    .subtitle-panel {
+      max-width: 100%;
+      padding: 18px 30px 20px;
+      border: 1px solid rgb(255 255 255 / 16%);
+      border-radius: 20px;
+      background: rgb(12 18 28 / 78%);
+      box-shadow: 0 10px 36px rgb(0 0 0 / 30%);
+      backdrop-filter: blur(12px);
+    }
+
+    .subtitle-zh {
+      font-size: ${layout.zhFontSize}px;
+      font-weight: 650;
+      line-height: 1.3;
+      letter-spacing: 0.01em;
+      text-shadow: 0 2px 8px rgb(0 0 0 / 80%);
+    }
+
+    .subtitle-en {
+      margin-top: 8px;
+      color: rgb(255 255 255 / 88%);
+      font-size: ${layout.enFontSize}px;
+      font-weight: 500;
+      line-height: 1.35;
+      text-shadow: 0 2px 7px rgb(0 0 0 / 82%);
+    }
+  </style>
+</head>
+<body>
+  <main class="subtitle-stage" aria-label="双语字幕">
+    <div class="subtitle-panel">
+      <div class="subtitle-zh" lang="zh-CN">${zh}</div>
+      <div class="subtitle-en" lang="en">${en}</div>
+    </div>
+  </main>
+</body>
+</html>
+`;
+}
+
+export async function writeSubtitleArtifacts(
+  outputDir: string,
+  cues: readonly StoryboardCue[] = VOICEOVER_CUES,
+): Promise<SubtitleArtifactPaths> {
+  validateSubtitleTimeline(cues);
+  await mkdir(outputDir, { recursive: true });
+
+  const paths: SubtitleArtifactPaths = {
+    zh: join(outputDir, 'work-review.zh.srt'),
+    en: join(outputDir, 'work-review.en.srt'),
+    bilingual: join(outputDir, 'work-review.bilingual.srt'),
+  };
+
+  await Promise.all([
+    writeFile(paths.zh, buildSrt(cues, 'zh'), 'utf8'),
+    writeFile(paths.en, buildSrt(cues, 'en'), 'utf8'),
+    writeFile(paths.bilingual, buildBilingualSrt(cues), 'utf8'),
+  ]);
+
+  return paths;
+}
+
+function buildSrtFromLines(
+  cues: readonly StoryboardCue[],
+  getLines: (cue: StoryboardCue) => readonly string[],
+): string {
+  const entries = cues.map((cue, index) => [
+    String(index + 1),
+    `${formatSrtTimestamp(cue.start)} --> ${formatSrtTimestamp(cue.end)}`,
+    ...getLines(cue),
+  ].join('\n'));
+
+  return `${entries.join('\n\n')}\n`;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[character] ?? character);
+}

--- a/scripts/product-demo/tauriMock.test.ts
+++ b/scripts/product-demo/tauriMock.test.ts
@@ -213,10 +213,19 @@ test('助手 Channel 按步骤、令牌、完成、结束顺序发送，活动�
     references: [],
     digest: '已检查今天的活动记录',
   });
-  assert.equal(events.some((event) => event.message?.type === 'token'), true);
+  const streamedAnswer = events
+    .filter((event) => event.message?.type === 'token')
+    .map((event) => String(event.message?.token ?? ''))
+    .join('');
+  assert.equal(streamedAnswer, state.fixtures.assistant.aiAnswer);
   assert.equal(events.at(-2)?.message?.type, 'done');
   assert.equal(events.at(-1)?.end, true);
   assert.deepEqual(events.map((event) => event.index), events.map((_, index) => index));
+});
+
+test('关于页读取固定演示版本号', async () => {
+  const state = createState();
+  assert.equal(await handleDemoInvoke(state, 'plugin:app|version', {}), '1.1.1-demo');
 });
 
 test('动态问题生成固定 JSON，未知命令明确抛错', async () => {

--- a/scripts/product-demo/tauriMock.test.ts
+++ b/scripts/product-demo/tauriMock.test.ts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
+import { setTimeout as sleep } from 'node:timers/promises';
 import test from 'node:test';
+
+import { Channel } from '@tauri-apps/api/core';
 
 import { buildHistoryPayload } from '../../src/routes/ask/historyPayload.ts';
 import { createDemoFixtures } from './fixtures.ts';
@@ -12,11 +15,80 @@ import {
 
 const createState = () => createDemoMockState(createDemoFixtures());
 
+function readPngSize(base64: string): { width: number; height: number; bytes: Buffer } {
+  const bytes = Buffer.from(base64, 'base64');
+  assert.deepEqual([...bytes.subarray(0, 8)], [137, 80, 78, 71, 13, 10, 26, 10]);
+  return {
+    width: bytes.readUInt32BE(16),
+    height: bytes.readUInt32BE(20),
+    bytes,
+  };
+}
 
-test('浏览器初始化脚本序列化后不依赖 tsx 的 __name 辅助函数', async () => {
+function readPngInternationalText(bytes: Buffer): string[] {
+  const texts: string[] = [];
+  let offset = 8;
+  while (offset + 12 <= bytes.length) {
+    const length = bytes.readUInt32BE(offset);
+    const type = bytes.toString('ascii', offset + 4, offset + 8);
+    const dataStart = offset + 8;
+    const dataEnd = dataStart + length;
+    if (dataEnd + 4 > bytes.length) break;
+    if (type === 'iTXt') texts.push(bytes.toString('utf8', dataStart, dataEnd));
+    offset = dataEnd + 4;
+  }
+  return texts;
+}
+
+async function installBrowserHarness() {
   let source = '';
+  const exposed = new Map<string, (...args: any[]) => Promise<any>>();
   const context = {
-    exposeFunction: async () => {},
+    exposeFunction: async (name: string, callback: (...args: any[]) => Promise<any>) => {
+      exposed.set(name, callback);
+    },
+    addInitScript: async (script: unknown) => {
+      source = typeof script === 'function'
+        ? String(script)
+        : String((script as { content?: unknown }).content ?? '');
+    },
+  };
+  const state = await installDemoTauriMock(
+    context as unknown as Parameters<typeof installDemoTauriMock>[0],
+    createDemoFixtures(),
+  );
+  const timerDelays: number[] = [];
+  let timerTurn = 0;
+  const localStorageValues = new Map<string, string>();
+  const windowObject: Record<string, any> = {
+    localStorage: {
+      setItem: (key: string, value: string) => localStorageValues.set(key, value),
+    },
+    __WORK_REVIEW_DEMO_INVOKE__: exposed.get('__WORK_REVIEW_DEMO_INVOKE__'),
+    __WORK_REVIEW_DEMO_SHOT_INVOKES__: exposed.get('__WORK_REVIEW_DEMO_SHOT_INVOKES__'),
+    __WORK_REVIEW_DEMO_EXPORTED_FILES__: exposed.get('__WORK_REVIEW_DEMO_EXPORTED_FILES__'),
+  };
+  const fakeSetTimeout = (callback: () => void, milliseconds = 0) => {
+    timerDelays.push(Number(milliseconds));
+    timerTurn += 1;
+    queueMicrotask(callback);
+    return 0;
+  };
+  new Function('window', 'setTimeout', source)(windowObject, fakeSetTimeout);
+  return {
+    state,
+    windowObject,
+    timerDelays,
+    getTimerTurn: () => timerTurn,
+  };
+}
+
+
+test('浏览器初始化脚本序列化后不依赖 tsx 的 __name 辅助函数并暴露只读调用日志', async () => {
+  let source = '';
+  const exposedFunctions: string[] = [];
+  const context = {
+    exposeFunction: async (name: string) => { exposedFunctions.push(name); },
     addInitScript: async (script: unknown) => {
       source = typeof script === 'function'
         ? String(script)
@@ -30,6 +102,11 @@ test('浏览器初始化脚本序列化后不依赖 tsx 的 __name 辅助函数'
   );
 
   assert.notEqual(source, '');
+  assert.deepEqual(exposedFunctions, [
+    '__WORK_REVIEW_DEMO_INVOKE__',
+    '__WORK_REVIEW_DEMO_SHOT_INVOKES__',
+    '__WORK_REVIEW_DEMO_EXPORTED_FILES__',
+  ]);
   assert.doesNotMatch(source, /\b__name\b/);
   assert.doesNotThrow(() => new Function(source));
 });
@@ -57,6 +134,94 @@ test('读取配置、统计、时间线、单活动详情和截图缩略图', as
   assert.match(String(thumbnail), /^[A-Za-z0-9+/]+=*$/);
 });
 
+
+test('截图 Mock 返回按活动区分的确定性脱敏工作卡片，不包含真实路径或真实应用内容', async () => {
+  const state = createState();
+  const fictionalApps = [
+    'Nebula IDE',
+    'Atlas Browser',
+    'Paperwork Docs',
+    'Orbit Meet',
+    'Canvas Lab',
+    'Nova Console',
+  ];
+  const previews: string[] = [];
+
+  for (const [index, activity] of state.fixtures.activities.entries()) {
+    const first = String(await handleDemoInvoke(state, 'get_screenshot_thumbnail', {
+      path: activity.screenshotPath,
+    }));
+    const second = String(await handleDemoInvoke(state, 'get_screenshot_thumbnail', {
+      path: activity.screenshotPath,
+    }));
+    const full = String(await handleDemoInvoke(state, 'get_screenshot_full', {
+      path: activity.screenshotPath,
+    }));
+    assert.equal(first, second);
+    assert.equal(first, full);
+
+    const { width, height, bytes } = readPngSize(first);
+    assert.ok(width >= 640 && height >= 360, `${activity.id} 的预览尺寸必须明显大于 1×1`);
+    const metadata = readPngInternationalText(bytes).join('\n');
+    assert.match(metadata, /已脱敏/);
+    assert.match(metadata, /Aurora Board/);
+    assert.match(metadata, new RegExp(fictionalApps[index]));
+    assert.doesNotMatch(metadata, /Cursor|Terminal|Figma|docs\.example\.test|npm run|\/Users\/|\/tmp\/|Work_Review/);
+    previews.push(first);
+  }
+
+  assert.equal(new Set(previews).size, state.fixtures.activities.length);
+});
+
+test('应用图标命令返回空值以触发安全的内置回退图标', async () => {
+  const state = createState();
+
+  assert.equal(
+    await handleDemoInvoke(state, 'get_app_icon', {
+      appName: 'Cursor',
+      executablePath: null,
+    }),
+    '',
+  );
+  assert.deepEqual(state.unhandledCommands, []);
+});
+
+test('系统权限检查返回固定且全部可用的 macOS 演示状态', async () => {
+  const state = createState();
+
+  assert.deepEqual(await handleDemoInvoke(state, 'check_permissions', {}), {
+    screen_capture: true,
+    accessibility: true,
+    input_monitoring: true,
+    screenshot_supported: true,
+    avatar_input_supported: true,
+    all_granted: true,
+    platform: 'macos',
+  });
+  assert.deepEqual(state.unhandledCommands, []);
+});
+
+test('About 页面可读取并保存隔离的更新设置', async () => {
+  const state = createState();
+
+  const settings = await handleDemoInvoke(state, 'get_update_settings', {});
+  assert.deepEqual(settings, {
+    autoCheck: true,
+    lastCheckTime: 0,
+    checkIntervalHours: 24,
+  });
+
+  await handleDemoInvoke(state, 'save_update_settings', {
+    settings: {
+      autoCheck: false,
+      lastCheckTime: 0,
+      checkIntervalHours: 24,
+    },
+  });
+
+  assert.equal(await handleDemoInvoke(state, 'should_check_updates', {}), false);
+});
+
 test('日报生成前为空，生成后可读取并按段落保存修改', async () => {
   const state = createState();
 
@@ -68,11 +233,18 @@ test('日报生成前为空，生成后可读取并按段落保存修改', async
     null,
   );
 
-  await handleDemoInvoke(state, 'generate_report', {
+  const generationStartedAt = performance.now();
+  const generation = handleDemoInvoke(state, 'generate_report', {
     date: state.fixtures.date,
     force: true,
     locale: 'zh-CN',
   });
+  await sleep(100);
+  assert.equal(state.reportGenerated, false, '生成短延迟期间应保持骨架状态');
+  await generation;
+  const generationElapsed = performance.now() - generationStartedAt;
+  assert.ok(generationElapsed >= 600, `生成延迟过短：${generationElapsed.toFixed(0)}ms`);
+  assert.ok(generationElapsed < 2_000, `生成延迟过长：${generationElapsed.toFixed(0)}ms`);
   const generated = await handleDemoInvoke(state, 'get_saved_report', {
     date: state.fixtures.date,
     locale: 'zh-CN',
@@ -112,6 +284,37 @@ test('保存隐私三档和截图设置，只记录安全目录打开与虚拟 M
   assert.deepEqual(state.openedDirectories, [state.fixtures.dataDir]);
   assert.equal(exportPath, state.fixtures.exportPath);
   assert.equal(state.exportedFiles[state.fixtures.exportPath], state.fixtures.report.content);
+});
+
+test('capture 层可读取 UI 实际导出的结构化 Markdown 快照且不能污染 Mock state', async () => {
+  const { state, windowObject } = await installBrowserHarness();
+  const exportedContent = '# Aurora Board 日报\n\n- 已脱敏的虚构工作成果。';
+
+  const exportPath = await windowObject.__TAURI_INTERNALS__.invoke('export_report_markdown', {
+    date: state.fixtures.date,
+    content: exportedContent,
+    exportDir: `${state.fixtures.safeRoot}exports/`,
+  });
+  const firstSnapshot = await windowObject.__WORK_REVIEW_DEMO_EXPORTED_FILES__();
+
+  assert.equal(exportPath, state.fixtures.exportPath);
+  assert.deepEqual(firstSnapshot, [
+    {
+      path: state.fixtures.exportPath,
+      content: exportedContent,
+      kind: 'markdown',
+    },
+  ]);
+  assert.doesNotMatch(JSON.stringify(firstSnapshot), /\/Users\/|\.worktrees\/|product-demo-impl/);
+
+  firstSnapshot[0].content = '不应写回 Mock state';
+  assert.deepEqual(await windowObject.__WORK_REVIEW_DEMO_EXPORTED_FILES__(), [
+    {
+      path: state.fixtures.exportPath,
+      content: exportedContent,
+      kind: 'markdown',
+    },
+  ]);
 });
 
 test('助手基础模板和演示 AI 复用同一会话，并保留第一轮完整历史', async () => {
@@ -185,10 +388,10 @@ test('演示 AI 接受真实 buildHistoryPayload 追加的工具摘要', async (
   }));
 });
 
-test('助手 Channel 按步骤、令牌、完成、结束顺序发送，活动查询不虚构引用', async () => {
+test('演示 AI Channel 返回与 Aurora Board 实现、文档和前端验证一致的非零引用', async () => {
   const state = createState();
 
-  await handleDemoInvoke(state, 'chat_work_assistant', {
+  const answer = await handleDemoInvoke(state, 'chat_work_assistant', {
     question: state.fixtures.assistant.aiQuestion,
     history: [
       { role: 'user', content: state.fixtures.assistant.basicQuestion },
@@ -197,22 +400,31 @@ test('助手 Channel 按步骤、令牌、完成、结束顺序发送，活动�
     modelConfig: state.fixtures.assistant.modelProfile.model_config,
     requestId: 'request-ai',
     onEvent: { id: 77 },
-  });
+  }) as { references: Array<Record<string, unknown>> };
 
   const events = takePendingChannelEvents(state, 77);
   assert.deepEqual(events.slice(0, 2).map((event) => event.message?.type), [
     'stepStart',
     'stepResult',
   ]);
-  assert.deepEqual(events[1].message, {
-    type: 'stepResult',
-    requestId: 'request-ai',
-    tool: 'query_activities',
-    ok: true,
-    hits: 0,
-    references: [],
-    digest: '已检查今天的活动记录',
-  });
+  const stepResult = events[1].message ?? {};
+  const references = stepResult.references as Array<Record<string, unknown>>;
+  assert.equal(stepResult.tool, 'query_activities');
+  assert.equal(stepResult.ok, true);
+  assert.equal(stepResult.hits, 3);
+  assert.deepEqual(references.map((reference) => reference.sourceId), [101, 103, 106]);
+  assert.deepEqual(references.map((reference) => reference.timestamp), [
+    state.fixtures.activities[0].timestamp,
+    state.fixtures.activities[2].timestamp,
+    state.fixtures.activities[5].timestamp,
+  ]);
+  assert.match(String(references[0].title), /Aurora Board.*导出流程/);
+  assert.match(String(references[1].title), /Aurora Board.*发布检查清单/);
+  assert.match(String(references[2].title), /16:40.*前端验证/);
+  assert.match(String(stepResult.digest), /3 条.*实现.*文档.*16:40.*前端验证/);
+  assert.deepEqual(answer.references, references);
+  assert.deepEqual(events.at(-2)?.message?.references, references);
+
   const streamedAnswer = events
     .filter((event) => event.message?.type === 'token')
     .map((event) => String(event.message?.token ?? ''))
@@ -221,6 +433,43 @@ test('助手 Channel 按步骤、令牌、完成、结束顺序发送，活动�
   assert.equal(events.at(-2)?.message?.type, 'done');
   assert.equal(events.at(-1)?.end, true);
   assert.deepEqual(events.map((event) => event.index), events.map((_, index) => index));
+});
+
+test('浏览器 Channel 通过确定性有限延迟分批派发，现有 Tauri Channel 可逐批消费', async () => {
+  const harness = await installBrowserHarness();
+  const previousWindow = Reflect.get(globalThis, 'window');
+  Reflect.set(globalThis, 'window', harness.windowObject);
+  try {
+    const received: Array<{ event: Record<string, unknown>; timerTurn: number }> = [];
+    const channel = new Channel<Record<string, unknown>>();
+    channel.onmessage = (event) => received.push({
+      event,
+      timerTurn: harness.getTimerTurn(),
+    });
+
+    await harness.windowObject.__TAURI_INTERNALS__.invoke('chat_work_assistant', {
+      question: harness.state.fixtures.assistant.aiQuestion,
+      history: [
+        { role: 'user', content: harness.state.fixtures.assistant.basicQuestion },
+        { role: 'assistant', content: harness.state.fixtures.assistant.basicAnswer },
+      ],
+      modelConfig: harness.state.fixtures.assistant.modelProfile.model_config,
+      requestId: 'request-ai-stream',
+      onEvent: channel,
+    });
+
+    const tokens = received.filter(({ event }) => event.type === 'token');
+    assert.ok(tokens.length >= 4);
+    assert.ok(new Set(tokens.map(({ timerTurn }) => timerTurn)).size >= 4);
+    assert.ok(harness.timerDelays.length >= tokens.length);
+    assert.ok(harness.timerDelays.every((delay) => delay > 0 && delay <= 250));
+    const totalScheduledDelay = harness.timerDelays.reduce((total, delay) => total + delay, 0);
+    assert.ok(totalScheduledDelay >= 600 && totalScheduledDelay <= 1_500);
+    assert.equal(received.at(-1)?.event.type, 'done');
+  } finally {
+    if (previousWindow === undefined) Reflect.deleteProperty(globalThis, 'window');
+    else Reflect.set(globalThis, 'window', previousWindow);
+  }
 });
 
 test('关于页读取固定演示版本号', async () => {
@@ -242,6 +491,7 @@ test('动态问题生成固定 JSON，未知命令明确抛错', async () => {
     handleDemoInvoke(state, 'unknown_demo_command', {}),
     /unknown_demo_command/,
   );
+  assert.deepEqual(state.unhandledCommands, ['unknown_demo_command']);
 });
 
 async function persistRound(

--- a/scripts/product-demo/tauriMock.test.ts
+++ b/scripts/product-demo/tauriMock.test.ts
@@ -1,0 +1,258 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildHistoryPayload } from '../../src/routes/ask/historyPayload.ts';
+import { createDemoFixtures } from './fixtures.ts';
+import {
+  createDemoMockState,
+  handleDemoInvoke,
+  installDemoTauriMock,
+  takePendingChannelEvents,
+} from './tauriMock.ts';
+
+const createState = () => createDemoMockState(createDemoFixtures());
+
+
+test('浏览器初始化脚本序列化后不依赖 tsx 的 __name 辅助函数', async () => {
+  let source = '';
+  const context = {
+    exposeFunction: async () => {},
+    addInitScript: async (script: unknown) => {
+      source = typeof script === 'function'
+        ? String(script)
+        : String((script as { content?: unknown }).content ?? '');
+    },
+  };
+
+  await installDemoTauriMock(
+    context as unknown as Parameters<typeof installDemoTauriMock>[0],
+    createDemoFixtures(),
+  );
+
+  assert.notEqual(source, '');
+  assert.doesNotMatch(source, /\b__name\b/);
+  assert.doesNotThrow(() => new Function(source));
+});
+
+test('读取配置、统计、时间线、单活动详情和截图缩略图', async () => {
+  const state = createState();
+  const config = await handleDemoInvoke(state, 'get_config', {});
+  const stats = await handleDemoInvoke(state, 'get_today_stats', {});
+  const timeline = await handleDemoInvoke(state, 'get_timeline', {
+    date: state.fixtures.date,
+    limit: 100,
+    offset: 0,
+  });
+  const activity = await handleDemoInvoke(state, 'get_activity', { id: 106 });
+  const thumbnail = await handleDemoInvoke(state, 'get_screenshot_thumbnail', {
+    path: state.fixtures.activities[0].screenshotPath,
+  });
+
+  assert.deepEqual((config as Record<string, unknown>).text_model_profiles, [
+    state.fixtures.assistant.modelProfile,
+  ]);
+  assert.equal((stats as { total_duration: number }).total_duration, 19_800);
+  assert.equal((timeline as Array<{ app_name: string }>).length, 6);
+  assert.equal((activity as { window_title: string }).window_title, 'npm run verify:frontend');
+  assert.match(String(thumbnail), /^[A-Za-z0-9+/]+=*$/);
+});
+
+test('日报生成前为空，生成后可读取并按段落保存修改', async () => {
+  const state = createState();
+
+  assert.equal(
+    await handleDemoInvoke(state, 'get_saved_report', {
+      date: state.fixtures.date,
+      locale: 'zh-CN',
+    }),
+    null,
+  );
+
+  await handleDemoInvoke(state, 'generate_report', {
+    date: state.fixtures.date,
+    force: true,
+    locale: 'zh-CN',
+  });
+  const generated = await handleDemoInvoke(state, 'get_saved_report', {
+    date: state.fixtures.date,
+    locale: 'zh-CN',
+  });
+  assert.equal(state.reportGenerated, true);
+  assert.equal((generated as { content: string }).content, state.fixtures.report.content);
+
+  const edited = `${state.fixtures.report.content}\n\n已显式保存段落。`;
+  await handleDemoInvoke(state, 'update_report_content', {
+    date: state.fixtures.date,
+    locale: 'zh-CN',
+    content: edited,
+  });
+  assert.equal(state.reportContent, edited);
+});
+
+test('保存隐私三档和截图设置，只记录安全目录打开与虚拟 Markdown 导出', async () => {
+  const state = createState();
+  const config = await handleDemoInvoke(state, 'get_config', {}) as Record<string, any>;
+  config.privacy.app_rules = [
+    { app_name: 'Cursor', level: 'full' },
+    { app_name: '浏览器', level: 'anonymized' },
+    { app_name: '会议', level: 'ignored' },
+  ];
+  config.storage.screenshots_enabled = false;
+
+  await handleDemoInvoke(state, 'save_config', { config });
+  await handleDemoInvoke(state, 'open_data_dir', {});
+  const exportPath = await handleDemoInvoke(state, 'export_report_markdown', {
+    date: state.fixtures.date,
+    content: state.fixtures.report.content,
+    exportDir: `${state.fixtures.safeRoot}exports/`,
+  });
+
+  assert.deepEqual(state.privacyRules, config.privacy.app_rules);
+  assert.equal(state.screenshotsEnabled, false);
+  assert.deepEqual(state.openedDirectories, [state.fixtures.dataDir]);
+  assert.equal(exportPath, state.fixtures.exportPath);
+  assert.equal(state.exportedFiles[state.fixtures.exportPath], state.fixtures.report.content);
+});
+
+test('助手基础模板和演示 AI 复用同一会话，并保留第一轮完整历史', async () => {
+  const state = createState();
+  const conversationId = await handleDemoInvoke(state, 'create_assistant_conversation', {
+    title: state.fixtures.assistant.basicQuestion,
+  });
+
+  const basic = await handleDemoInvoke(state, 'chat_work_assistant', {
+    question: state.fixtures.assistant.basicQuestion,
+    history: [],
+    modelConfig: null,
+    requestId: 'request-basic',
+    onEvent: { id: 41 },
+  }) as { answer: string; usedAi: boolean; modelName: string | null };
+  await persistRound(state, Number(conversationId), state.fixtures.assistant.basicQuestion, basic);
+
+  const history = [
+    { role: 'user', content: state.fixtures.assistant.basicQuestion },
+    { role: 'assistant', content: state.fixtures.assistant.basicAnswer },
+  ];
+  const ai = await handleDemoInvoke(state, 'chat_work_assistant', {
+    question: state.fixtures.assistant.aiQuestion,
+    history,
+    modelConfig: state.fixtures.assistant.modelProfile.model_config,
+    requestId: 'request-ai',
+    onEvent: '__CHANNEL__:42',
+  }) as { answer: string; usedAi: boolean; modelName: string | null };
+  await persistRound(state, Number(conversationId), state.fixtures.assistant.aiQuestion, ai);
+
+  assert.equal(state.conversationCreateCalls, 1);
+  assert.equal(state.chatCalls, 2);
+  assert.equal(state.appendCalls, 4);
+  assert.equal(state.assistantMessages.every((message) => message.conversationId === conversationId), true);
+  assert.deepEqual(state.chatRequests[1].history, history);
+  assert.equal(basic.answer, state.fixtures.assistant.basicAnswer);
+  assert.equal(basic.usedAi, false);
+  assert.equal(ai.answer, state.fixtures.assistant.aiAnswer);
+  assert.equal(ai.usedAi, true);
+  assert.equal(ai.modelName, state.fixtures.assistant.modelProfile.name);
+});
+
+test('演示 AI 接受真实 buildHistoryPayload 追加的工具摘要', async () => {
+  const state = createState();
+  const history = buildHistoryPayload([
+    { role: 'user', content: state.fixtures.assistant.basicQuestion },
+    {
+      role: 'assistant',
+      content: state.fixtures.assistant.basicAnswer,
+      streaming: false,
+      steps: [
+        {
+          tool: 'get_today_stats',
+          label: '汇总今日统计',
+          status: 'done',
+          ok: true,
+          hits: 0,
+          digest: '已汇总今天的工作统计',
+        },
+      ],
+    },
+  ]);
+
+  assert.match(history[1].content, /\[工具：get_today_stats✓\]/);
+  await assert.doesNotReject(handleDemoInvoke(state, 'chat_work_assistant', {
+    question: state.fixtures.assistant.aiQuestion,
+    history,
+    modelConfig: state.fixtures.assistant.modelProfile.model_config,
+    requestId: 'request-ai-real-history',
+    onEvent: { id: 76 },
+  }));
+});
+
+test('助手 Channel 按步骤、令牌、完成、结束顺序发送，活动查询不虚构引用', async () => {
+  const state = createState();
+
+  await handleDemoInvoke(state, 'chat_work_assistant', {
+    question: state.fixtures.assistant.aiQuestion,
+    history: [
+      { role: 'user', content: state.fixtures.assistant.basicQuestion },
+      { role: 'assistant', content: state.fixtures.assistant.basicAnswer },
+    ],
+    modelConfig: state.fixtures.assistant.modelProfile.model_config,
+    requestId: 'request-ai',
+    onEvent: { id: 77 },
+  });
+
+  const events = takePendingChannelEvents(state, 77);
+  assert.deepEqual(events.slice(0, 2).map((event) => event.message?.type), [
+    'stepStart',
+    'stepResult',
+  ]);
+  assert.deepEqual(events[1].message, {
+    type: 'stepResult',
+    requestId: 'request-ai',
+    tool: 'query_activities',
+    ok: true,
+    hits: 0,
+    references: [],
+    digest: '已检查今天的活动记录',
+  });
+  assert.equal(events.some((event) => event.message?.type === 'token'), true);
+  assert.equal(events.at(-2)?.message?.type, 'done');
+  assert.equal(events.at(-1)?.end, true);
+  assert.deepEqual(events.map((event) => event.index), events.map((_, index) => index));
+});
+
+test('动态问题生成固定 JSON，未知命令明确抛错', async () => {
+  const state = createState();
+  assert.equal(
+    await handleDemoInvoke(state, 'generate_text_with_model', {
+      modelConfig: state.fixtures.assistant.modelProfile.model_config,
+      prompt: '生成问题',
+    }),
+    '["今天最值得总结的成果是什么？"]',
+  );
+
+  await assert.rejects(
+    handleDemoInvoke(state, 'unknown_demo_command', {}),
+    /unknown_demo_command/,
+  );
+});
+
+async function persistRound(
+  state: ReturnType<typeof createState>,
+  conversationId: number,
+  question: string,
+  answer: { answer: string; modelName: string | null },
+): Promise<void> {
+  await handleDemoInvoke(state, 'append_assistant_message', {
+    conversationId,
+    role: 'user',
+    content: question,
+    toolDigest: null,
+    modelName: null,
+  });
+  await handleDemoInvoke(state, 'append_assistant_message', {
+    conversationId,
+    role: 'assistant',
+    content: answer.answer,
+    toolDigest: null,
+    modelName: answer.modelName,
+  });
+}

--- a/scripts/product-demo/tauriMock.ts
+++ b/scripts/product-demo/tauriMock.ts
@@ -238,8 +238,7 @@ function normalizeHistory(value: unknown): DemoAssistantHistoryMessage[] {
 }
 
 function chunkAnswer(answer: string): string[] {
-  const chunks = answer.match(/.{1,18}(?:[，。；]|$)/gu) ?? [answer];
-  return chunks.filter(Boolean);
+  return Array.from(answer.matchAll(/[\s\S]{1,18}/gu), (match) => match[0]);
 }
 
 function buildAssistantEvents(
@@ -324,6 +323,8 @@ export async function handleDemoInvoke(
       return null;
     case 'plugin:window|is_visible':
       return true;
+    case 'plugin:app|version':
+      return '1.1.1-demo';
     case 'get_platform':
     case 'get_runtime_platform':
       return 'macos';

--- a/scripts/product-demo/tauriMock.ts
+++ b/scripts/product-demo/tauriMock.ts
@@ -1,3 +1,5 @@
+import { deflateSync } from 'node:zlib';
+
 import type { BrowserContext } from 'playwright';
 
 import type {
@@ -9,8 +11,55 @@ import type {
   DemoStoredAssistantMessage,
 } from './types.ts';
 
-const TINY_JPEG_BASE64 =
-  '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAX/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAF//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABBQJ//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAwEBPwF//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAgEBPwF//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQAGPwJ//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABPyF//9oADAMBAAIAAwAAABD/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/EB//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/EB//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/EB//2Q==';
+const REPORT_GENERATION_DELAY_MS = 700;
+const ASSISTANT_STREAM_DELAY_MS = 140;
+const PREVIEW_WIDTH = 640;
+const PREVIEW_HEIGHT = 360;
+const PREVIEW_DEFINITION = [
+  { app: 'Nebula IDE', context: 'Export flow implementation', accent: [79, 70, 229] },
+  { app: 'Atlas Browser', context: 'Product specification review', accent: [14, 165, 233] },
+  { app: 'Paperwork Docs', context: 'Release checklist notes', accent: [16, 185, 129] },
+  { app: 'Orbit Meet', context: 'Weekly release sync', accent: [245, 158, 11] },
+  { app: 'Canvas Lab', context: 'Vertical layout concept', accent: [236, 72, 153] },
+  { app: 'Nova Console', context: 'Frontend verification', accent: [139, 92, 246] },
+] as const;
+
+const REDACTED_GLYPHS = [
+  [0x0, 0x0, 0x1ffe0, 0x20, 0x20, 0x20, 0x18020, 0x1ffe0, 0x18020, 0x18020, 0x18000, 0x18000, 0x18000, 0x18008, 0x18018, 0xfff0, 0x0, 0x0, 0x0, 0x0],
+  [0x0, 0x10, 0x630, 0x1f320, 0x11160, 0x117f8, 0x11408, 0x1f408, 0x11408, 0x11408, 0x1f7f8, 0x11160, 0x11160, 0x11160, 0x31360, 0x31764, 0x27e3c, 0x6400, 0x0, 0x0],
+  [0x0, 0xc0c0, 0x80c0, 0x1fe80, 0x10080, 0x201fc, 0x1fd18, 0x14f10, 0x12d90, 0x10890, 0x3fe90, 0x14890, 0x128e0, 0x10860, 0x1fe60, 0x8b0, 0x3b1c, 0x2604, 0x0, 0x0],
+] as const;
+
+
+const BITMAP_FONT: Record<string, readonly number[]> = {
+  ' ': [0, 0, 0, 0, 0, 0, 0],
+  A: [0b01110, 0b10001, 0b10001, 0b11111, 0b10001, 0b10001, 0b10001],
+  B: [0b11110, 0b10001, 0b10001, 0b11110, 0b10001, 0b10001, 0b11110],
+  C: [0b01111, 0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b01111],
+  D: [0b11110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b11110],
+  E: [0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b11111],
+  F: [0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b10000],
+  G: [0b01111, 0b10000, 0b10000, 0b10111, 0b10001, 0b10001, 0b01111],
+  H: [0b10001, 0b10001, 0b10001, 0b11111, 0b10001, 0b10001, 0b10001],
+  I: [0b11111, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b11111],
+  J: [0b00111, 0b00010, 0b00010, 0b00010, 0b10010, 0b10010, 0b01100],
+  K: [0b10001, 0b10010, 0b10100, 0b11000, 0b10100, 0b10010, 0b10001],
+  L: [0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b10000, 0b11111],
+  M: [0b10001, 0b11011, 0b10101, 0b10101, 0b10001, 0b10001, 0b10001],
+  N: [0b10001, 0b11001, 0b10101, 0b10011, 0b10001, 0b10001, 0b10001],
+  O: [0b01110, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01110],
+  P: [0b11110, 0b10001, 0b10001, 0b11110, 0b10000, 0b10000, 0b10000],
+  Q: [0b01110, 0b10001, 0b10001, 0b10001, 0b10101, 0b10010, 0b01101],
+  R: [0b11110, 0b10001, 0b10001, 0b11110, 0b10100, 0b10010, 0b10001],
+  S: [0b01111, 0b10000, 0b10000, 0b01110, 0b00001, 0b00001, 0b11110],
+  T: [0b11111, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100],
+  U: [0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01110],
+  V: [0b10001, 0b10001, 0b10001, 0b10001, 0b10001, 0b01010, 0b00100],
+  W: [0b10001, 0b10001, 0b10001, 0b10101, 0b10101, 0b10101, 0b01010],
+  X: [0b10001, 0b10001, 0b01010, 0b00100, 0b01010, 0b10001, 0b10001],
+  Y: [0b10001, 0b10001, 0b01010, 0b00100, 0b00100, 0b00100, 0b00100],
+  Z: [0b11111, 0b00001, 0b00010, 0b00100, 0b01000, 0b10000, 0b11111],
+};
 
 interface AssistantAnswer {
   answer: string;
@@ -18,6 +67,208 @@ interface AssistantAnswer {
   usedAi: boolean;
   modelName: string | null;
   toolLabels: string[];
+}
+
+interface DemoAssistantReference {
+  sourceType: 'activity';
+  sourceId: number;
+  date: string;
+  timestamp: number;
+  title: string;
+  excerpt: string;
+  appName: string;
+  browserUrl: null;
+  duration: number;
+  score: number;
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ ((crc & 1) === 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Uint8Array): Buffer {
+  const typeBytes = Buffer.from(type, 'ascii');
+  const body = Buffer.concat([typeBytes, data]);
+  const chunk = Buffer.alloc(data.length + 12);
+  chunk.writeUInt32BE(data.length, 0);
+  body.copy(chunk, 4);
+  chunk.writeUInt32BE(crc32(body), data.length + 8);
+  return chunk;
+}
+
+function createInternationalTextChunk(text: string): Buffer {
+  return pngChunk(
+    'iTXt',
+    Buffer.concat([
+      Buffer.from('Description', 'ascii'),
+      Buffer.from([0, 0, 0, 0, 0]),
+      Buffer.from(text, 'utf8'),
+    ]),
+  );
+}
+
+function fillRect(
+  pixels: Buffer,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  color: readonly number[],
+): void {
+  const startX = Math.max(0, x);
+  const startY = Math.max(0, y);
+  const endX = Math.min(PREVIEW_WIDTH, x + width);
+  const endY = Math.min(PREVIEW_HEIGHT, y + height);
+  for (let row = startY; row < endY; row += 1) {
+    for (let column = startX; column < endX; column += 1) {
+      const offset = (row * PREVIEW_WIDTH + column) * 4;
+      pixels[offset] = color[0] ?? 0;
+      pixels[offset + 1] = color[1] ?? 0;
+      pixels[offset + 2] = color[2] ?? 0;
+      pixels[offset + 3] = color[3] ?? 255;
+    }
+  }
+}
+
+function drawBitmapText(
+  pixels: Buffer,
+  x: number,
+  y: number,
+  text: string,
+  scale: number,
+  color: readonly number[],
+): void {
+  let cursorX = x;
+  for (const character of text.toUpperCase()) {
+    const rows = BITMAP_FONT[character] ?? BITMAP_FONT[' '];
+    for (const [rowIndex, rowBits] of rows.entries()) {
+      for (let column = 0; column < 5; column += 1) {
+        if ((rowBits & (1 << (4 - column))) === 0) continue;
+        fillRect(
+          pixels,
+          cursorX + column * scale,
+          y + rowIndex * scale,
+          scale,
+          scale,
+          color,
+        );
+      }
+    }
+    cursorX += 6 * scale;
+  }
+}
+
+function drawRedactedBadge(pixels: Buffer): void {
+  const scale = 3;
+  const glyphWidth = 20 * scale;
+  const gap = 8;
+  const badgeWidth = REDACTED_GLYPHS.length * glyphWidth + (REDACTED_GLYPHS.length - 1) * gap + 48;
+  const badgeX = PREVIEW_WIDTH - badgeWidth - 28;
+  const badgeY = 24;
+  fillRect(pixels, badgeX, badgeY, badgeWidth, 84, [15, 23, 42, 235]);
+  for (const [glyphIndex, rows] of REDACTED_GLYPHS.entries()) {
+    const glyphX = badgeX + 24 + glyphIndex * (glyphWidth + gap);
+    for (const [rowIndex, rowBits] of rows.entries()) {
+      for (let column = 0; column < 20; column += 1) {
+        if ((rowBits & (1 << (19 - column))) === 0) continue;
+        fillRect(
+          pixels,
+          glyphX + column * scale,
+          badgeY + 12 + rowIndex * scale,
+          scale,
+          scale,
+          [255, 255, 255, 255],
+        );
+      }
+    }
+  }
+}
+
+function buildPreviewPng(metadata: string, accent: readonly number[], variant: number): string {
+  const pixels = Buffer.alloc(PREVIEW_WIDTH * PREVIEW_HEIGHT * 4);
+  fillRect(pixels, 0, 0, PREVIEW_WIDTH, PREVIEW_HEIGHT, [241, 245, 249, 255]);
+  fillRect(pixels, 0, 0, PREVIEW_WIDTH, 48, [15, 23, 42, 255]);
+  drawBitmapText(pixels, 24, 16, 'Aurora Board', 2, [255, 255, 255, 255]);
+  fillRect(pixels, 24, 76, 592, 260, [255, 255, 255, 255]);
+  fillRect(pixels, 24, 76, 12, 260, [...accent, 255]);
+  drawBitmapText(
+    pixels,
+    62,
+    102,
+    PREVIEW_DEFINITION[variant % PREVIEW_DEFINITION.length].app,
+    3,
+    [51, 65, 85, 255],
+  );
+  fillRect(pixels, 62, 138, 420 - variant * 13, 12, [148, 163, 184, 255]);
+  fillRect(pixels, 62, 168, 360 + variant * 17, 12, [203, 213, 225, 255]);
+  fillRect(pixels, 62, 214, 128, 88, [...accent, 42]);
+  fillRect(pixels, 210, 214, 174, 88, [226, 232, 240, 255]);
+  fillRect(pixels, 404, 214, 170, 88, [226, 232, 240, 255]);
+  drawRedactedBadge(pixels);
+
+  const scanlines = Buffer.alloc(PREVIEW_HEIGHT * (PREVIEW_WIDTH * 4 + 1));
+  for (let row = 0; row < PREVIEW_HEIGHT; row += 1) {
+    const destination = row * (PREVIEW_WIDTH * 4 + 1);
+    scanlines[destination] = 0;
+    pixels.copy(scanlines, destination + 1, row * PREVIEW_WIDTH * 4, (row + 1) * PREVIEW_WIDTH * 4);
+  }
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(PREVIEW_WIDTH, 0);
+  header.writeUInt32BE(PREVIEW_HEIGHT, 4);
+  header[8] = 8;
+  header[9] = 6;
+  return Buffer.concat([
+    Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+    pngChunk('IHDR', header),
+    createInternationalTextChunk(metadata),
+    pngChunk('IDAT', deflateSync(scanlines, { level: 9 })),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]).toString('base64');
+}
+
+function buildSafePreview(fixtures: DemoFixtures, path: unknown): string {
+  const index = fixtures.activities.findIndex((activity) => activity.screenshotPath === path);
+  const variant = index >= 0 ? index : 0;
+  const definition = PREVIEW_DEFINITION[variant % PREVIEW_DEFINITION.length];
+  const metadata = `已脱敏 | Aurora Board | ${definition.app} | ${definition.context}`;
+  return buildPreviewPng(metadata, definition.accent, variant);
+}
+
+function buildAiReferences(fixtures: DemoFixtures): DemoAssistantReference[] {
+  const selected = [fixtures.activities[0], fixtures.activities[2], fixtures.activities[5]];
+  const titles = [
+    'Aurora Board 上午导出流程实现',
+    'Aurora Board 上午发布检查清单文档',
+    '16:40 Aurora Board 前端验证通过',
+  ];
+  const excerpts = [
+    '上午完成导出流程实现与端到端整理。',
+    '上午补充发布检查清单与文档记录。',
+    '16:40 完成前端验证，检查结果通过。',
+  ];
+  return selected.map((activity, index) => ({
+    sourceType: 'activity',
+    sourceId: activity.id,
+    date: fixtures.date,
+    timestamp: activity.timestamp,
+    title: titles[index],
+    excerpt: excerpts[index],
+    appName: PREVIEW_DEFINITION[[0, 2, 5][index]].app,
+    browserUrl: null,
+    duration: activity.duration,
+    score: 1 - index * 0.05,
+  }));
 }
 
 function createDemoConfig(fixtures: DemoFixtures): Record<string, unknown> {
@@ -152,6 +403,7 @@ export function createDemoMockState(fixtures: DemoFixtures): DemoMockState {
     appendCalls: 0,
     chatRequests: [],
     pendingChannelEvents: {},
+    unhandledCommands: [],
   };
 }
 
@@ -248,7 +500,10 @@ function buildAssistantEvents(
 ): DemoChannelEnvelope[] {
   const tool = isAi ? 'query_activities' : 'get_today_stats';
   const label = isAi ? '查询今日活动' : '汇总今日统计';
-  const digest = isAi ? '已检查今天的活动记录' : '已汇总今天的工作统计';
+  const digest = isAi
+    ? '命中 3 条 Aurora Board 记录：上午实现、上午文档和 16:40 前端验证。'
+    : '已汇总今天的工作统计';
+  const references = answer.references;
   const messages: Array<Record<string, unknown>> = [
     {
       type: 'stepStart',
@@ -261,8 +516,8 @@ function buildAssistantEvents(
       requestId: request.requestId,
       tool,
       ok: true,
-      hits: 0,
-      references: [],
+      hits: references.length,
+      references,
       digest,
     },
     ...chunkAnswer(answer.answer).map((token) => ({
@@ -274,7 +529,7 @@ function buildAssistantEvents(
       type: 'done',
       requestId: request.requestId,
       answer: answer.answer,
-      references: [],
+      references,
       toolLabels: [label],
       usedAi: answer.usedAi,
       modelName: answer.modelName,
@@ -328,8 +583,28 @@ export async function handleDemoInvoke(
     case 'get_platform':
     case 'get_runtime_platform':
       return 'macos';
+    case 'check_permissions':
+      return {
+        screen_capture: true,
+        accessibility: true,
+        input_monitoring: true,
+        screenshot_supported: true,
+        avatar_input_supported: true,
+        all_granted: true,
+        platform: 'macos',
+      };
     case 'get_config':
       return clone(state.config);
+    case 'get_update_settings':
+      return {
+        autoCheck: true,
+        lastCheckTime: 0,
+        checkIntervalHours: 24,
+      };
+    case 'save_update_settings':
+      return null;
+    case 'should_check_updates':
+      return false;
     case 'save_config': {
       const config = args.config;
       if (typeof config !== 'object' || config === null || Array.isArray(config)) {
@@ -374,9 +649,12 @@ export async function handleDemoInvoke(
           duration: activity.duration,
         }],
       }));
+    case 'get_app_icon':
+      // 演示不读取宿主机应用图标；返回空值让前端使用确定性的内置回退图标。
+      return '';
     case 'get_screenshot_thumbnail':
     case 'get_screenshot_full':
-      return TINY_JPEG_BASE64;
+      return buildSafePreview(state.fixtures, args.path);
     case 'get_saved_report':
       if (!state.reportGenerated || args.date !== state.fixtures.date) return null;
       return {
@@ -386,6 +664,7 @@ export async function handleDemoInvoke(
         ai_mode: 'local',
       };
     case 'generate_report':
+      await sleep(REPORT_GENERATION_DELAY_MS);
       state.reportGenerated = true;
       state.reportContent = state.fixtures.report.content;
       return null;
@@ -497,7 +776,7 @@ export async function handleDemoInvoke(
       if (isAi) assertAiHistory(state, request.history);
       const answer: AssistantAnswer = {
         answer: isAi ? state.fixtures.assistant.aiAnswer : state.fixtures.assistant.basicAnswer,
-        references: [],
+        references: isAi ? buildAiReferences(state.fixtures) : [],
         usedAi: isAi,
         modelName: isAi ? state.fixtures.assistant.modelProfile.name : null,
         toolLabels: [isAi ? '查询今日活动' : '汇总今日统计'],
@@ -514,6 +793,7 @@ export async function handleDemoInvoke(
     case 'confirm_assistant_action':
       return null;
     default:
+      state.unhandledCommands.push(command);
       throw new Error(`产品演示 Tauri Mock 未实现命令：${command}`);
   }
 }
@@ -574,8 +854,10 @@ function buildDemoTauriInitScript(locale: DemoFixtures['locale']): string {
         }
         const response = await window.__WORK_REVIEW_DEMO_INVOKE__(command, normalizedArgs);
         if (response.channelId !== null) {
+          const deliver = callbacks.get(response.channelId);
           for (const event of response.events) {
-            callbacks.get(response.channelId)?.(event);
+            await new Promise((resolve) => setTimeout(resolve, ${ASSISTANT_STREAM_DELAY_MS}));
+            deliver?.(event);
           }
         }
         return response.result;
@@ -601,6 +883,20 @@ export async function installDemoTauriMock(
         events: channelId === null ? [] : takePendingChannelEvents(state, channelId),
       };
     },
+  );
+
+  await context.exposeFunction(
+    '__WORK_REVIEW_DEMO_SHOT_INVOKES__',
+    async () => clone(state.invokeLog),
+  );
+
+  await context.exposeFunction(
+    '__WORK_REVIEW_DEMO_EXPORTED_FILES__',
+    async () => clone(Object.entries(state.exportedFiles).map(([path, content]) => ({
+      path,
+      content,
+      kind: 'markdown' as const,
+    }))),
   );
 
   // 通过纯 JavaScript 字符串注入，避免 tsx/esbuild 给序列化函数插入浏览器中不存在的 __name 辅助函数。

--- a/scripts/product-demo/tauriMock.ts
+++ b/scripts/product-demo/tauriMock.ts
@@ -1,0 +1,609 @@
+import type { BrowserContext } from 'playwright';
+
+import type {
+  DemoAssistantHistoryMessage,
+  DemoAssistantRequest,
+  DemoChannelEnvelope,
+  DemoFixtures,
+  DemoMockState,
+  DemoStoredAssistantMessage,
+} from './types.ts';
+
+const TINY_JPEG_BASE64 =
+  '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAX/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAF//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABBQJ//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAwEBPwF//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAgEBPwF//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQAGPwJ//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABPyF//9oADAMBAAIAAwAAABD/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/EB//xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/EB//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/EB//2Q==';
+
+interface AssistantAnswer {
+  answer: string;
+  references: unknown[];
+  usedAi: boolean;
+  modelName: string | null;
+  toolLabels: string[];
+}
+
+function createDemoConfig(fixtures: DemoFixtures): Record<string, unknown> {
+  return {
+    theme: 'light',
+    ui_visual_style: 'b',
+    background_image: null,
+    background_opacity: 0.25,
+    background_blur: 1,
+    daily_work_goal_minutes: 420,
+    standard_work_hours: 7.5,
+    work_time_enabled: true,
+    work_time_segments: [
+      { start_hour: 9, start_minute: 0, end_hour: 12, end_minute: 0 },
+      { start_hour: 13, start_minute: 30, end_hour: 18, end_minute: 0 },
+    ],
+    work_start_hour: 9,
+    work_start_minute: 0,
+    work_end_hour: 18,
+    work_end_minute: 0,
+    auto_start: false,
+    auto_start_silent: true,
+    hide_dock_icon: false,
+    lightweight_mode: false,
+    break_reminder_enabled: false,
+    break_reminder_interval_minutes: 50,
+    avatar_enabled: false,
+    avatar_scale: 0.9,
+    avatar_opacity: 0.82,
+    avatar_preset: 'original-standard',
+    avatar_persona: 'assistant',
+    avatar_click_through: false,
+    avatar_proactive_ai_enabled: false,
+    idle_threshold_minutes: 5,
+    goal_notifications: false,
+    memory_enabled: false,
+    daily_report_auto_generate_time: null,
+    daily_report_custom_prompt: '',
+    daily_report_export_dir: `${fixtures.safeRoot}exports/`,
+    daily_report_auto_export: false,
+    daily_report_prompt_presets: [],
+    daily_report_system_prompt_override: '',
+    daily_report_pinned_blocks: [],
+    daily_report_hidden_blocks: [],
+    screenshot_interval: 30,
+    storage: {
+      screenshot_retention_days: 14,
+      metadata_retention_days: 60,
+      storage_limit_mb: 4096,
+      jpeg_quality: 85,
+      max_image_width: 1920,
+      screenshots_enabled: fixtures.privacy.screenshotsEnabled,
+      screenshot_display_mode: 'active_window',
+      screenshot_width_mode: 'auto',
+    },
+    remote_storage: {
+      provider: 'none',
+      s3: {
+        endpoint: '',
+        region: '',
+        bucket: '',
+        access_key: '',
+        secret_key: '',
+        path_prefix: '',
+        public_url_base: null,
+      },
+      webdav: {
+        url: '',
+        username: '',
+        password: '',
+        path_prefix: '',
+        public_url_base: null,
+      },
+    },
+    privacy: {
+      app_rules: structuredClone(fixtures.privacy.appRules),
+      excluded_keywords: [],
+      excluded_domains: [],
+    },
+    app_category_rules: [],
+    ai_mode: 'local',
+    ai_provider: {
+      provider: 'ollama',
+      endpoint: 'http://127.0.0.1:11434',
+      api_key: null,
+      model: 'demo-vision',
+      vision_model: 'demo-vision',
+    },
+    text_model: structuredClone(fixtures.assistant.modelProfile.model_config),
+    text_model_profiles: [structuredClone(fixtures.assistant.modelProfile)],
+    assistant_web_access_enabled: false,
+    memory_semantic_enabled: false,
+    node_devices: [],
+    node_gateway: { device_name: 'Work Review Demo' },
+    mcp_server_enabled: false,
+    localhost_api_enabled: false,
+    localhost_api_port: 47831,
+    localhost_api_host: '127.0.0.1',
+    telegram_bot_enabled: false,
+    telegram_bot_token: null,
+    telegram_bot_proxy: null,
+    feishu_bot_enabled: false,
+    feishu_app_id: null,
+    feishu_app_secret: null,
+    wecom_bot_enabled: false,
+    wecom_corp_id: null,
+    wecom_token: null,
+    wecom_encoding_aes_key: null,
+    dingtalk_bot_enabled: false,
+    dingtalk_app_secret: null,
+  };
+}
+
+export function createDemoMockState(fixtures: DemoFixtures): DemoMockState {
+  const safeFixtures = structuredClone(fixtures);
+  return {
+    fixtures: safeFixtures,
+    config: createDemoConfig(safeFixtures),
+    reportGenerated: false,
+    reportContent: safeFixtures.report.content,
+    selectedAssistantModel: '__basic__',
+    assistantMessages: [],
+    assistantConversationCreated: false,
+    privacyRules: structuredClone(safeFixtures.privacy.appRules),
+    screenshotsEnabled: safeFixtures.privacy.screenshotsEnabled,
+    exportedFiles: {},
+    openedDirectories: [],
+    invokeLog: [],
+    nextMessageId: 1,
+    conversationCreateCalls: 0,
+    chatCalls: 0,
+    appendCalls: 0,
+    chatRequests: [],
+    pendingChannelEvents: {},
+  };
+}
+
+function recordInvoke(
+  state: DemoMockState,
+  command: string,
+  args: Record<string, unknown>,
+): void {
+  state.invokeLog.push({ command, args: structuredClone(args), at: Date.now() });
+}
+
+function toTimelineActivity(activity: DemoFixtures['activities'][number]) {
+  return {
+    id: activity.id,
+    timestamp: activity.timestamp,
+    app_name: activity.app,
+    window_title: activity.title,
+    screenshot_path: activity.screenshotPath,
+    ocr_text: activity.ocrText,
+    category: activity.category,
+    duration: activity.duration,
+    browser_url: activity.browserUrl,
+    executable_path: null,
+    semantic_category: null,
+    semantic_confidence: null,
+  };
+}
+
+function toStats(fixtures: DemoFixtures) {
+  return {
+    total_duration: fixtures.stats.totalDuration,
+    work_time_duration: fixtures.stats.workTimeDuration,
+    screenshot_count: fixtures.stats.screenshotCount,
+    app_usage: fixtures.stats.apps.map((item) => ({
+      app_name: item.appName,
+      duration: item.duration,
+      count: item.count,
+    })),
+    category_usage: structuredClone(fixtures.stats.categories),
+    hourly_activity: structuredClone(fixtures.stats.hourlyActivity),
+    browser_duration: fixtures.stats.categories.find((item) => item.category === 'browser')?.duration ?? 0,
+    url_usage: [],
+    domain_usage: [],
+    domain_total_count: 0,
+    browser_usage: [],
+  };
+}
+
+function toHourlySummaries(fixtures: DemoFixtures) {
+  return fixtures.activities.map((activity) => ({
+    id: 10_000 + activity.id,
+    date: fixtures.date,
+    hour: Number(activity.time.slice(0, 2)),
+    summary: `${activity.time} 使用 ${activity.app}：${activity.title}。`,
+    main_apps: activity.app,
+    activity_count: 1,
+    total_duration: activity.duration,
+    representative_screenshots: activity.screenshotPath,
+    created_at: activity.timestamp,
+  }));
+}
+
+function extractChannelId(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value)) return value;
+  if (typeof value === 'string') {
+    const match = /^__CHANNEL__:(\d+)$/.exec(value);
+    return match ? Number(match[1]) : null;
+  }
+  if (typeof value === 'object' && value !== null && 'id' in value) {
+    const id = (value as { id?: unknown }).id;
+    return typeof id === 'number' && Number.isInteger(id) ? id : null;
+  }
+  return null;
+}
+
+function normalizeHistory(value: unknown): DemoAssistantHistoryMessage[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (typeof item !== 'object' || item === null) return [];
+    const { role, content } = item as { role?: unknown; content?: unknown };
+    if ((role !== 'user' && role !== 'assistant') || typeof content !== 'string') return [];
+    return [{ role, content }];
+  });
+}
+
+function chunkAnswer(answer: string): string[] {
+  const chunks = answer.match(/.{1,18}(?:[，。；]|$)/gu) ?? [answer];
+  return chunks.filter(Boolean);
+}
+
+function buildAssistantEvents(
+  request: DemoAssistantRequest,
+  answer: AssistantAnswer,
+  isAi: boolean,
+): DemoChannelEnvelope[] {
+  const tool = isAi ? 'query_activities' : 'get_today_stats';
+  const label = isAi ? '查询今日活动' : '汇总今日统计';
+  const digest = isAi ? '已检查今天的活动记录' : '已汇总今天的工作统计';
+  const messages: Array<Record<string, unknown>> = [
+    {
+      type: 'stepStart',
+      requestId: request.requestId,
+      tool,
+      label,
+    },
+    {
+      type: 'stepResult',
+      requestId: request.requestId,
+      tool,
+      ok: true,
+      hits: 0,
+      references: [],
+      digest,
+    },
+    ...chunkAnswer(answer.answer).map((token) => ({
+      type: 'token',
+      requestId: request.requestId,
+      token,
+    })),
+    {
+      type: 'done',
+      requestId: request.requestId,
+      answer: answer.answer,
+      references: [],
+      toolLabels: [label],
+      usedAi: answer.usedAi,
+      modelName: answer.modelName,
+    },
+  ];
+  return [
+    ...messages.map((message, index) => ({ index, message })),
+    { index: messages.length, end: true },
+  ];
+}
+
+function assertAiHistory(state: DemoMockState, history: DemoAssistantHistoryMessage[]): void {
+  const expected = [
+    { role: 'user', content: state.fixtures.assistant.basicQuestion },
+    { role: 'assistant', content: state.fixtures.assistant.basicAnswer },
+  ];
+  const hasExpectedRound = expected.every((item, index) => {
+    const actual = history[index];
+    if (actual?.role !== item.role) return false;
+    return item.role === 'assistant'
+      ? actual.content.startsWith(item.content)
+      : actual.content === item.content;
+  });
+  if (!hasExpectedRound) {
+    throw new Error('演示 AI 请求缺少同一会话中的基础模板完整历史');
+  }
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+export async function handleDemoInvoke(
+  state: DemoMockState,
+  command: string,
+  args: Record<string, unknown> = {},
+): Promise<unknown> {
+  recordInvoke(state, command, args);
+
+  switch (command) {
+    case 'plugin:event|listen':
+      return args.handler;
+    case 'plugin:event|unlisten':
+    case 'plugin:event|emit':
+    case 'plugin:event|emit_to':
+      return null;
+    case 'plugin:window|is_visible':
+      return true;
+    case 'get_platform':
+    case 'get_runtime_platform':
+      return 'macos';
+    case 'get_config':
+      return clone(state.config);
+    case 'save_config': {
+      const config = args.config;
+      if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+        throw new TypeError('save_config 缺少有效 config');
+      }
+      state.config = clone(config as Record<string, unknown>);
+      const privacy = (state.config.privacy ?? {}) as { app_rules?: DemoFixtures['privacy']['appRules'] };
+      const storage = (state.config.storage ?? {}) as { screenshots_enabled?: boolean };
+      state.privacyRules = clone(privacy.app_rules ?? []);
+      state.screenshotsEnabled = storage.screenshots_enabled !== false;
+      return null;
+    }
+    case 'set_app_locale':
+    case 'set_report_block_preference':
+    case 'pause_recording':
+    case 'resume_recording':
+      return null;
+    case 'get_recording_state':
+      return [true, false];
+    case 'get_today_stats':
+    case 'get_daily_stats':
+    case 'get_overview_stats':
+      return toStats(state.fixtures);
+    case 'get_overview_domains':
+      return { domains: [], total_count: 0 };
+    case 'get_timeline':
+      return args.date === state.fixtures.date
+        ? state.fixtures.activities.map(toTimelineActivity)
+        : [];
+    case 'get_activity': {
+      const activity = state.fixtures.activities.find((item) => item.id === args.id);
+      return activity ? toTimelineActivity(activity) : null;
+    }
+    case 'get_hourly_summaries':
+      return args.date === state.fixtures.date ? toHourlySummaries(state.fixtures) : [];
+    case 'get_hourly_app_breakdown':
+      return state.fixtures.activities.map((activity) => ({
+        hour: Number(activity.time.slice(0, 2)),
+        apps: [{
+          app_name: activity.app,
+          category: activity.category,
+          duration: activity.duration,
+        }],
+      }));
+    case 'get_screenshot_thumbnail':
+    case 'get_screenshot_full':
+      return TINY_JPEG_BASE64;
+    case 'get_saved_report':
+      if (!state.reportGenerated || args.date !== state.fixtures.date) return null;
+      return {
+        date: state.fixtures.date,
+        content: state.reportContent,
+        created_at: state.fixtures.report.createdAt,
+        ai_mode: 'local',
+      };
+    case 'generate_report':
+      state.reportGenerated = true;
+      state.reportContent = state.fixtures.report.content;
+      return null;
+    case 'update_report_content': {
+      if (typeof args.content !== 'string') {
+        throw new TypeError('update_report_content 缺少 content');
+      }
+      state.reportGenerated = true;
+      state.reportContent = args.content;
+      return null;
+    }
+    case 'export_report_markdown': {
+      if (typeof args.content !== 'string') {
+        throw new TypeError('export_report_markdown 缺少 content');
+      }
+      state.exportedFiles[state.fixtures.exportPath] = args.content;
+      return state.fixtures.exportPath;
+    }
+    case 'open_data_dir':
+      state.openedDirectories.push(state.fixtures.dataDir);
+      return null;
+    case 'get_data_dir':
+    case 'get_default_data_dir':
+      return state.fixtures.dataDir;
+    case 'get_storage_stats':
+      return {
+        total_files: state.fixtures.stats.screenshotCount,
+        total_size_mb: 48,
+        storage_limit_mb: 4096,
+        retention_days: 14,
+        oldest_file_date: state.fixtures.date,
+      };
+    case 'get_categories':
+      return [
+        { key: 'development', name: '开发', color: '#6366f1', icon: 'code' },
+        { key: 'office', name: '办公', color: '#0ea5e9', icon: 'briefcase' },
+        { key: 'communication', name: '沟通', color: '#f59e0b', icon: 'message-circle' },
+        { key: 'browser', name: '浏览', color: '#10b981', icon: 'globe' },
+      ];
+    case 'get_semantic_categories':
+    case 'get_custom_semantic_categories':
+      return [];
+    case 'get_running_apps':
+    case 'get_recent_apps':
+      return state.fixtures.activities.map((activity) => activity.app);
+    case 'get_ai_providers':
+      return [{ id: 'ollama', name: 'Ollama', endpoint: 'http://127.0.0.1:11434' }];
+    case 'is_autostart_enabled':
+      return false;
+    case 'list_assistant_conversations':
+      return state.assistantConversationCreated
+        ? [{
+            id: state.fixtures.assistant.conversationId,
+            title: state.fixtures.assistant.basicQuestion,
+            createdAt: state.fixtures.report.createdAt,
+            updatedAt: state.fixtures.report.createdAt,
+            messageCount: state.assistantMessages.length,
+          }]
+        : [];
+    case 'create_assistant_conversation':
+      if (state.assistantConversationCreated) {
+        throw new Error('演示助手只允许创建一次会话');
+      }
+      state.assistantConversationCreated = true;
+      state.conversationCreateCalls += 1;
+      return state.fixtures.assistant.conversationId;
+    case 'append_assistant_message': {
+      const conversationId = Number(args.conversationId);
+      const role = args.role;
+      const content = args.content;
+      if (
+        conversationId !== state.fixtures.assistant.conversationId
+        || (role !== 'user' && role !== 'assistant')
+        || typeof content !== 'string'
+      ) {
+        throw new TypeError('append_assistant_message 参数无效');
+      }
+      const message: DemoStoredAssistantMessage = {
+        id: state.nextMessageId++,
+        conversationId,
+        role,
+        content,
+        toolDigest: typeof args.toolDigest === 'string' ? args.toolDigest : null,
+        modelName: typeof args.modelName === 'string' ? args.modelName : null,
+        createdAt: state.fixtures.report.createdAt + state.nextMessageId,
+      };
+      state.assistantMessages.push(message);
+      state.appendCalls += 1;
+      return message.id;
+    }
+    case 'get_assistant_messages':
+      return state.assistantMessages
+        .filter((message) => message.conversationId === Number(args.conversationId))
+        .map((message) => clone(message));
+    case 'generate_text_with_model':
+      return '["今天最值得总结的成果是什么？"]';
+    case 'chat_work_assistant': {
+      const modelConfig = args.modelConfig === null
+        ? null
+        : clone(args.modelConfig as DemoFixtures['assistant']['modelProfile']['model_config']);
+      const request: DemoAssistantRequest = {
+        question: String(args.question ?? ''),
+        history: normalizeHistory(args.history),
+        modelConfig,
+        requestId: String(args.requestId ?? ''),
+        channelId: extractChannelId(args.onEvent),
+      };
+      const isAi = modelConfig !== null;
+      if (isAi) assertAiHistory(state, request.history);
+      const answer: AssistantAnswer = {
+        answer: isAi ? state.fixtures.assistant.aiAnswer : state.fixtures.assistant.basicAnswer,
+        references: [],
+        usedAi: isAi,
+        modelName: isAi ? state.fixtures.assistant.modelProfile.name : null,
+        toolLabels: [isAi ? '查询今日活动' : '汇总今日统计'],
+      };
+      state.selectedAssistantModel = isAi ? 'demo-ai' : '__basic__';
+      state.chatCalls += 1;
+      state.chatRequests.push(request);
+      if (request.channelId !== null) {
+        state.pendingChannelEvents[request.channelId] = buildAssistantEvents(request, answer, isAi);
+      }
+      return answer;
+    }
+    case 'cancel_assistant_request':
+    case 'confirm_assistant_action':
+      return null;
+    default:
+      throw new Error(`产品演示 Tauri Mock 未实现命令：${command}`);
+  }
+}
+
+export function takePendingChannelEvents(
+  state: DemoMockState,
+  channelId: number,
+): DemoChannelEnvelope[] {
+  const events = state.pendingChannelEvents[channelId] ?? [];
+  delete state.pendingChannelEvents[channelId];
+  return clone(events);
+}
+
+function buildDemoTauriInitScript(locale: DemoFixtures['locale']): string {
+  const serializedLocale = JSON.stringify(locale);
+  return `(() => {
+    window.localStorage.setItem('work-review.locale', ${serializedLocale});
+    window.localStorage.setItem('theme', 'light');
+    window.localStorage.setItem(
+      'work-review-assistant-state',
+      JSON.stringify({
+        messages: [],
+        selectedModelId: '__basic__',
+        hasUserSelectedModel: true,
+        sending: false,
+        sendingRequestId: null,
+        conversationId: null,
+      }),
+    );
+
+    const callbacks = new Map();
+    let nextCallbackId = 1;
+    const registerCallback = (callback, once = false) => {
+      const id = nextCallbackId++;
+      callbacks.set(id, (data) => {
+        if (once) callbacks.delete(id);
+        return callback?.(data);
+      });
+      return id;
+    };
+
+    window.__TAURI_EVENT_PLUGIN_INTERNALS__ = { unregisterListener: () => {} };
+    window.__TAURI_INTERNALS__ = {
+      metadata: {
+        currentWindow: { label: 'main' },
+        currentWebview: { windowLabel: 'main', label: 'main' },
+      },
+      callbacks,
+      transformCallback: registerCallback,
+      unregisterCallback: (id) => callbacks.delete(id),
+      runCallback: (id, data) => callbacks.get(id)?.(data),
+      convertFileSrc: (filePath) => filePath,
+      invoke: async (command, args = {}) => {
+        const normalizedArgs = { ...args };
+        const onEvent = normalizedArgs.onEvent;
+        if (typeof onEvent === 'object' && onEvent !== null && 'id' in onEvent) {
+          normalizedArgs.onEvent = { id: onEvent.id };
+        }
+        const response = await window.__WORK_REVIEW_DEMO_INVOKE__(command, normalizedArgs);
+        if (response.channelId !== null) {
+          for (const event of response.events) {
+            callbacks.get(response.channelId)?.(event);
+          }
+        }
+        return response.result;
+      },
+    };
+  })();`;
+}
+
+export async function installDemoTauriMock(
+  context: BrowserContext,
+  fixtures: DemoFixtures,
+): Promise<DemoMockState> {
+  const state = createDemoMockState(fixtures);
+
+  await context.exposeFunction(
+    '__WORK_REVIEW_DEMO_INVOKE__',
+    async (command: string, args: Record<string, unknown> = {}) => {
+      const result = await handleDemoInvoke(state, command, args);
+      const channelId = extractChannelId(args.onEvent);
+      return {
+        result,
+        channelId,
+        events: channelId === null ? [] : takePendingChannelEvents(state, channelId),
+      };
+    },
+  );
+
+  // 通过纯 JavaScript 字符串注入，避免 tsx/esbuild 给序列化函数插入浏览器中不存在的 __name 辅助函数。
+  await context.addInitScript({ content: buildDemoTauriInitScript(fixtures.locale) });
+
+  return state;
+}

--- a/scripts/product-demo/types.ts
+++ b/scripts/product-demo/types.ts
@@ -1,0 +1,151 @@
+import type { Page } from 'playwright';
+
+export type DemoAspect = '16x9' | '9x16';
+export type StoryboardSceneId =
+  | 'hook'
+  | 'timeline'
+  | 'report'
+  | 'assistant'
+  | 'privacy'
+  | 'export'
+  | 'outro';
+export type AssistantStage = 'basic-template' | 'demo-ai';
+
+export interface DemoComposition {
+  crop: string;
+  scale: string;
+  focus: string;
+}
+
+export interface StoryboardCue {
+  id: string;
+  start: number;
+  end: number;
+  zh: string;
+  en: string;
+}
+
+export interface StoryboardScene {
+  id: StoryboardSceneId;
+  start: number;
+  end: number;
+  route: string;
+  voiceoverZh: string;
+  subtitleEn: string;
+  composition: Record<DemoAspect, DemoComposition>;
+  assistantStages?: AssistantStage[];
+}
+
+export interface DemoActivity {
+  id: number;
+  time: string;
+  timestamp: number;
+  app: string;
+  title: string;
+  category: string;
+  duration: number;
+  browserUrl: string | null;
+  screenshotPath: string;
+  ocrText: string | null;
+}
+
+export interface DemoCategoryStat {
+  category: string;
+  duration: number;
+}
+
+export interface DemoAppStat {
+  appName: string;
+  duration: number;
+  count: number;
+}
+
+export interface DemoReportSection {
+  title: string;
+  markdown: string;
+}
+
+export interface DemoFixtures {
+  date: string;
+  timezone: string;
+  locale: 'zh-CN';
+  project: string;
+  safeRoot: string;
+  dataDir: string;
+  exportPath: string;
+  activities: DemoActivity[];
+  stats: {
+    totalDuration: number;
+    workTimeDuration: number;
+    screenshotCount: number;
+    categories: DemoCategoryStat[];
+    apps: DemoAppStat[];
+    hourlyActivity: Array<{ hour: number; duration: number }>;
+  };
+  report: {
+    createdAt: number;
+    sections: DemoReportSection[];
+    content: string;
+  };
+  assistant: {
+    conversationId: number;
+    basicQuestion: string;
+    basicAnswer: string;
+    aiQuestion: string;
+    aiAnswer: string;
+    modelProfile: {
+      id: 'demo-ai';
+      name: string;
+      model_config: {
+        provider: string;
+        endpoint: string;
+        api_key: null;
+        model: string;
+      };
+    };
+  };
+  privacy: {
+    appRules: Array<{ app_name: string; level: 'full' | 'anonymized' | 'ignored' }>;
+    screenshotsEnabled: boolean;
+  };
+}
+
+export interface DemoInvokeLogEntry {
+  command: string;
+  args: Record<string, unknown>;
+  at: number;
+}
+
+export interface DemoStoredAssistantMessage {
+  id: number;
+  conversationId: number;
+  role: 'user' | 'assistant';
+  content: string;
+  toolDigest: string | null;
+  modelName: string | null;
+  createdAt: number;
+}
+
+export interface DemoMockState {
+  fixtures: DemoFixtures;
+  reportGenerated: boolean;
+  reportContent: string;
+  selectedAssistantModel: '__basic__' | 'demo-ai';
+  assistantMessages: DemoStoredAssistantMessage[];
+  assistantConversationCreated: boolean;
+  privacyRules: DemoFixtures['privacy']['appRules'];
+  screenshotsEnabled: boolean;
+  exportedFiles: Record<string, string>;
+  openedDirectories: string[];
+  invokeLog: DemoInvokeLogEntry[];
+  nextMessageId: number;
+}
+
+export interface ShotContext {
+  page: Page;
+  aspect: DemoAspect;
+  scene: StoryboardScene;
+  fixtures: DemoFixtures;
+}
+
+export type ShotRunner = (context: ShotContext) => Promise<void>;

--- a/scripts/product-demo/types.ts
+++ b/scripts/product-demo/types.ts
@@ -126,8 +126,28 @@ export interface DemoStoredAssistantMessage {
   createdAt: number;
 }
 
+export interface DemoAssistantHistoryMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface DemoAssistantRequest {
+  question: string;
+  history: DemoAssistantHistoryMessage[];
+  modelConfig: DemoFixtures['assistant']['modelProfile']['model_config'] | null;
+  requestId: string;
+  channelId: number | null;
+}
+
+export interface DemoChannelEnvelope {
+  index: number;
+  message?: Record<string, unknown>;
+  end?: true;
+}
+
 export interface DemoMockState {
   fixtures: DemoFixtures;
+  config: Record<string, unknown>;
   reportGenerated: boolean;
   reportContent: string;
   selectedAssistantModel: '__basic__' | 'demo-ai';
@@ -139,6 +159,11 @@ export interface DemoMockState {
   openedDirectories: string[];
   invokeLog: DemoInvokeLogEntry[];
   nextMessageId: number;
+  conversationCreateCalls: number;
+  chatCalls: number;
+  appendCalls: number;
+  chatRequests: DemoAssistantRequest[];
+  pendingChannelEvents: Record<number, DemoChannelEnvelope[]>;
 }
 
 export interface ShotContext {

--- a/scripts/product-demo/types.ts
+++ b/scripts/product-demo/types.ts
@@ -164,6 +164,7 @@ export interface DemoMockState {
   appendCalls: number;
   chatRequests: DemoAssistantRequest[];
   pendingChannelEvents: Record<number, DemoChannelEnvelope[]>;
+  unhandledCommands: string[];
 }
 
 export interface ShotContext {
@@ -171,6 +172,10 @@ export interface ShotContext {
   aspect: DemoAspect;
   scene: StoryboardScene;
   fixtures: DemoFixtures;
+  /** 标记源录屏中正式内容开始的位置，合成时会跳过导航和字体加载预卷。 */
+  markContentStart?: () => void;
+  /** 在弹窗、三档隐私等关键瞬态仍可见时主动保存动作验收帧。 */
+  captureActionFrame?: () => Promise<void>;
 }
 
 export type ShotRunner = (context: ShotContext) => Promise<void>;

--- a/scripts/product-demo/validate.test.ts
+++ b/scripts/product-demo/validate.test.ts
@@ -1,0 +1,645 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import {
+  lstat,
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { syncBuiltinESMExports } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import type { MediaProbe } from './ffmpeg.ts';
+import {
+  buildDeliveryManifest,
+  formatSha256Sums,
+  parsePngDimensions,
+  parseSrtArtifact,
+  sha256Hex,
+  validateCoverArtifact,
+  validateDelivery,
+  validateMediaArtifact,
+  validateSubtitleArtifact,
+  writeManifest,
+  type KeyframeOcrFrame,
+} from './validate.ts';
+
+const KEYFRAME_ASPECTS = ['16x9', '9x16'] as const;
+const KEYFRAME_SCENES = ['hook', 'timeline', 'report', 'assistant', 'privacy', 'export', 'outro'] as const;
+const KEYFRAME_PHASES = ['start', 'action', 'end'] as const;
+
+const SAFE_SRT = [
+  '1',
+  '00:00:00,350 --> 00:00:06,650',
+  '下班时，你还记得今天到底做了什么吗？',
+  '',
+  '2',
+  '00:00:07,350 --> 00:00:18,650',
+  '当天轨迹按应用、页面和时间片整理。',
+  '',
+].join('\n');
+
+function validProbe(width = 1920, height = 1080): MediaProbe {
+  return {
+    durationSeconds: 85,
+    formatName: 'mov,mp4,m4a,3gp,3g2,mj2',
+    video: {
+      codec: 'h264',
+      pixelFormat: 'yuv420p',
+      width,
+      height,
+      frameRate: 30,
+      averageFrameRate: 30,
+      frameCount: 2550,
+      durationSeconds: 85,
+    },
+    audio: {
+      codec: 'aac',
+      sampleRate: 48_000,
+      channels: 2,
+      channelLayout: 'stereo',
+      durationSeconds: 85,
+    },
+  };
+}
+
+function pngHeader(width: number, height: number): Buffer {
+  const buffer = Buffer.alloc(24);
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(buffer, 0);
+  buffer.writeUInt32BE(13, 8);
+  buffer.write('IHDR', 12, 'ascii');
+  buffer.writeUInt32BE(width, 16);
+  buffer.writeUInt32BE(height, 20);
+  return buffer;
+}
+
+async function createDeliveryFixture(): Promise<{
+  artifactDir: string;
+  logFiles: string[];
+  markdownFiles: string[];
+  sourceTextFiles: string[];
+  privacyObjects: Array<{ source: string; value: unknown }>;
+  runKeyframeOcr: (frames: readonly KeyframeOcrFrame[]) => Promise<{
+    available: true;
+    engine: string;
+    evidence: Array<{ relativePath: string; text: string }>;
+  }>;
+}> {
+  const artifactDir = await mkdtemp(path.join(tmpdir(), 'work-review-validate-'));
+  await mkdir(path.join(artifactDir, 'intermediate', 'exports'), { recursive: true });
+  await Promise.all(KEYFRAME_ASPECTS.map((aspect) => (
+    mkdir(path.join(artifactDir, 'intermediate', aspect), { recursive: true })
+  )));
+
+  const keyframeFiles = KEYFRAME_ASPECTS.flatMap((aspect) => (
+    KEYFRAME_SCENES.flatMap((scene) => (
+      KEYFRAME_PHASES.map((phase) => `intermediate/${aspect}/${scene}-${phase}.png`)
+    ))
+  ));
+
+  await Promise.all([
+    writeFile(path.join(artifactDir, 'work-review-demo-16x9.mp4'), 'fake-horizontal-video'),
+    writeFile(path.join(artifactDir, 'work-review-demo-9x16.mp4'), 'fake-vertical-video'),
+    writeFile(path.join(artifactDir, 'work-review-demo-zh.srt'), SAFE_SRT),
+    writeFile(path.join(artifactDir, 'work-review-demo-en.srt'), SAFE_SRT.replaceAll('下班时，你还记得今天到底做了什么吗？', 'Can you still recall what you accomplished today?').replaceAll('当天轨迹按应用、页面和时间片整理。', 'Your day is organized by apps, pages, and time blocks.')),
+    writeFile(path.join(artifactDir, 'work-review-demo-zh-en.srt'), SAFE_SRT.replaceAll('下班时，你还记得今天到底做了什么吗？', '下班时，你还记得今天到底做了什么吗？\nCan you still recall what you accomplished today?').replaceAll('当天轨迹按应用、页面和时间片整理。', '当天轨迹按应用、页面和时间片整理。\nYour day is organized by apps, pages, and time blocks.')),
+    writeFile(path.join(artifactDir, 'work-review-demo-cover-16x9.png'), pngHeader(1920, 1080)),
+    writeFile(path.join(artifactDir, 'work-review-demo-cover-9x16.png'), pngHeader(1080, 1920)),
+    writeFile(path.join(artifactDir, 'intermediate', 'capture.log'), '仅访问 http://127.0.0.1:5173/#/report\n'),
+    writeFile(path.join(artifactDir, 'intermediate', 'rendered.html'), '<main>Aurora Board 产品演示</main>\n'),
+    writeFile(path.join(artifactDir, 'intermediate', 'exports', '2026-08-12.md'), '# Aurora Board 日报\n\n今日完成导出流程。\n'),
+    ...keyframeFiles.map((relativePath) => (
+      writeFile(path.join(artifactDir, relativePath), pngHeader(4, 4))
+    )),
+  ]);
+
+  return {
+    artifactDir,
+    logFiles: ['intermediate/capture.log'],
+    markdownFiles: ['intermediate/exports/2026-08-12.md'],
+    sourceTextFiles: ['intermediate/rendered.html'],
+    privacyObjects: [{ source: 'demo-fixtures', value: { safeRoot: '/tmp/work-review-demo/' } }],
+    runKeyframeOcr: async (frames) => ({
+      available: true,
+      engine: 'unit-test-ocr',
+      evidence: frames.map((frame) => ({
+        relativePath: frame.relativePath,
+        text: `安全演示画面 ${frame.aspect} ${frame.scene} ${frame.phase}`,
+      })),
+    }),
+  };
+}
+
+test('验证横屏与竖屏媒体的完整目标规格', () => {
+  const horizontal = validateMediaArtifact({
+    aspect: '16x9',
+    relativePath: 'work-review-demo-16x9.mp4',
+    sizeBytes: 1024,
+    probe: validProbe(),
+  });
+  const vertical = validateMediaArtifact({
+    aspect: '9x16',
+    relativePath: 'work-review-demo-9x16.mp4',
+    sizeBytes: 2048,
+    probe: validProbe(1080, 1920),
+  });
+
+  assert.deepEqual(
+    [horizontal.width, horizontal.height, horizontal.frameRate, horizontal.frameCount],
+    [1920, 1080, 30, 2550],
+  );
+  assert.deepEqual(
+    [vertical.width, vertical.height, vertical.frameRate, vertical.frameCount],
+    [1080, 1920, 30, 2550],
+  );
+  assert.equal(horizontal.videoCodec, 'h264');
+  assert.equal(horizontal.audioCodec, 'aac');
+  assert.equal(horizontal.pixelFormat, 'yuv420p');
+});
+
+test('音轨时长必须接近固定 85 秒并允许一帧误差', () => {
+  const boundaryProbe = validProbe();
+  boundaryProbe.audio!.durationSeconds = 85 - (1 / 30);
+  assert.doesNotThrow(() => validateMediaArtifact({
+    aspect: '16x9',
+    relativePath: 'work-review-demo-16x9.mp4',
+    sizeBytes: 1,
+    probe: boundaryProbe,
+  }));
+
+  const shortProbe = validProbe();
+  shortProbe.audio!.durationSeconds = 85 - (1 / 30) - 0.001;
+  assert.throws(
+    () => validateMediaArtifact({
+      aspect: '16x9',
+      relativePath: 'work-review-demo-16x9.mp4',
+      sizeBytes: 1,
+      probe: shortProbe,
+    }),
+    /音频时长.*85 秒.*一帧误差/,
+  );
+});
+
+test('媒体验证明确报告时长、CFR、帧数、分辨率、编码、音轨和像素格式错误', () => {
+  const cases: Array<{ name: string; mutate: (probe: MediaProbe) => void; expected: RegExp }> = [
+    { name: '时长', mutate: (probe) => { probe.durationSeconds = 84.9; }, expected: /时长.*85/ },
+    { name: '视频流时长', mutate: (probe) => { probe.video!.durationSeconds = 84.9; }, expected: /视频流时长.*85/ },
+    { name: '视频流时长缺失', mutate: (probe) => { probe.video!.durationSeconds = null; }, expected: /视频流时长.*缺失/ },
+    { name: '标称帧率', mutate: (probe) => { probe.video!.frameRate = 29.97; }, expected: /恒定 30fps|标称帧率/ },
+    { name: '平均帧率', mutate: (probe) => { probe.video!.averageFrameRate = 29.5; }, expected: /恒定 30fps|平均帧率/ },
+    { name: '帧数', mutate: (probe) => { probe.video!.frameCount = 2549; }, expected: /2550 帧/ },
+    { name: '缺失帧数', mutate: (probe) => { probe.video!.frameCount = null; }, expected: /准确帧数|count_frames/ },
+    { name: '分辨率', mutate: (probe) => { probe.video!.width = 1280; }, expected: /1920×1080/ },
+    { name: '视频编码', mutate: (probe) => { probe.video!.codec = 'hevc'; }, expected: /H\.264/ },
+    { name: '缺少音轨', mutate: (probe) => { probe.audio = null; }, expected: /音轨/ },
+    { name: '音频编码', mutate: (probe) => { probe.audio!.codec = 'opus'; }, expected: /AAC/ },
+    { name: '像素格式', mutate: (probe) => { probe.video!.pixelFormat = 'yuv444p'; }, expected: /yuv420p/ },
+    { name: '音频残留', mutate: (probe) => { probe.video!.durationSeconds = 84.98; probe.audio!.durationSeconds = 85.02; }, expected: /音频.*超出/ },
+    { name: '音频时长缺失', mutate: (probe) => { probe.audio!.durationSeconds = null; }, expected: /音频时长.*缺失/ },
+    { name: '容器', mutate: (probe) => { probe.formatName = 'matroska,webm'; }, expected: /MP4/ },
+  ];
+
+  for (const item of cases) {
+    const probe = structuredClone(validProbe());
+    item.mutate(probe);
+    assert.throws(
+      () => validateMediaArtifact({
+        aspect: '16x9',
+        relativePath: 'work-review-demo-16x9.mp4',
+        sizeBytes: 1,
+        probe,
+      }),
+      item.expected,
+      item.name,
+    );
+  }
+});
+
+test('解析并验证 SRT 时间线，拒绝越界、重叠和倒序', () => {
+  const parsed = parseSrtArtifact(SAFE_SRT, 'zh.srt');
+  assert.equal(parsed.length, 2);
+  assert.deepEqual(parsed.map((cue) => [cue.startMilliseconds, cue.endMilliseconds]), [
+    [350, 6650],
+    [7350, 18650],
+  ]);
+  assert.equal(validateSubtitleArtifact(SAFE_SRT, 'zh.srt').cueCount, 2);
+
+  assert.throws(
+    () => validateSubtitleArtifact(SAFE_SRT.replace('00:00:18,650', '00:01:25,001'), 'overflow.srt'),
+    /超过.*85|越界/,
+  );
+  assert.throws(
+    () => validateSubtitleArtifact(SAFE_SRT.replace('00:00:07,350', '00:00:06,000'), 'overlap.srt'),
+    /重叠|倒序/,
+  );
+  assert.throws(
+    () => validateSubtitleArtifact('1\nnot-a-timecode\n字幕\n', 'broken.srt'),
+    /时间码|格式/,
+  );
+});
+
+test('解析 PNG 封面尺寸并按画幅验证', () => {
+  assert.deepEqual(parsePngDimensions(pngHeader(1920, 1080)), { width: 1920, height: 1080 });
+  assert.deepEqual(
+    validateCoverArtifact(pngHeader(1080, 1920), '9x16', 'cover.png'),
+    { width: 1080, height: 1920 },
+  );
+  assert.throws(
+    () => validateCoverArtifact(pngHeader(1000, 1000), '16x9', 'bad-cover.png'),
+    /1920×1080/,
+  );
+  assert.throws(() => parsePngDimensions(Buffer.from('not-png')), /PNG/);
+});
+
+test('完整交付验证检查媒体、三份 SRT 对齐、非空文件、封面、日志、虚拟 Markdown 与隐私', async () => {
+  const fixture = await createDeliveryFixture();
+  const result = await validateDelivery({
+    ...fixture,
+    probeMediaFile: async (filePath) => filePath.includes('9x16')
+      ? validProbe(1080, 1920)
+      : validProbe(),
+  });
+
+  assert.equal(result.files.length, 52);
+  assert.equal(result.media['16x9'].frameCount, 2550);
+  assert.equal(result.media['9x16'].height, 1920);
+  assert.deepEqual(result.subtitleTimelineMilliseconds, [[350, 6650], [7350, 18650]]);
+  assert.deepEqual(result.manualChecks, []);
+  assert.deepEqual(result.keyframeOcr, { engine: 'unit-test-ocr', evidenceCount: 42 });
+  assert.equal(result.integrityVerified, false);
+});
+
+
+test('关键帧 OCR 未接线或自动 OCR 明确不可用时阻断交付', async () => {
+  const fixture = await createDeliveryFixture();
+  const { runKeyframeOcr: _runKeyframeOcr, ...withoutOcr } = fixture;
+  const probeMediaFile = async (filePath: string) => filePath.includes('9x16')
+    ? validProbe(1080, 1920)
+    : validProbe();
+
+  await assert.rejects(
+    validateDelivery({ ...withoutOcr, probeMediaFile }),
+    /自动 OCR 不可用|未接线.*OCR/,
+  );
+  await assert.rejects(
+    validateDelivery({
+      ...fixture,
+      probeMediaFile,
+      runKeyframeOcr: async () => ({
+        available: false,
+        reason: '测试环境没有可用的自动 OCR 引擎',
+      }),
+    }),
+    /自动 OCR 不可用.*测试环境没有可用的自动 OCR 引擎/,
+  );
+});
+
+test('关键帧 OCR 必须覆盖横竖屏七镜头的 start、action、end，拒绝缺失和重复证据', async () => {
+  const fixture = await createDeliveryFixture();
+  const probeMediaFile = async (filePath: string) => filePath.includes('9x16')
+    ? validProbe(1080, 1920)
+    : validProbe();
+
+  await assert.rejects(
+    validateDelivery({
+      ...fixture,
+      probeMediaFile,
+      runKeyframeOcr: async (frames) => ({
+        available: true,
+        engine: 'unit-test-ocr',
+        evidence: frames.slice(0, -1).map((frame) => ({
+          relativePath: frame.relativePath,
+          text: '安全演示画面',
+        })),
+      }),
+    }),
+    /OCR 证据缺失.*9x16.*outro-end\.png/,
+  );
+
+  await assert.rejects(
+    validateDelivery({
+      ...fixture,
+      probeMediaFile,
+      runKeyframeOcr: async (frames) => ({
+        available: true,
+        engine: 'unit-test-ocr',
+        evidence: [
+          ...frames.map((frame) => ({ relativePath: frame.relativePath, text: '安全演示画面' })),
+          { relativePath: frames[0]!.relativePath, text: '重复证据' },
+        ],
+      }),
+    }),
+    /OCR 证据.*重复/,
+  );
+});
+
+test('扫描关键帧 OCR 文本，并继续扫描日志、Markdown、源码文本、旧 OCR 文本与隐私对象', async () => {
+  const probeMediaFile = async (filePath: string) => filePath.includes('9x16')
+    ? validProbe(1080, 1920)
+    : validProbe();
+
+  const ocrFixture = await createDeliveryFixture();
+  await assert.rejects(
+    validateDelivery({
+      ...ocrFixture,
+      probeMediaFile,
+      runKeyframeOcr: async (frames) => ({
+        available: true,
+        engine: 'unit-test-ocr',
+        evidence: frames.map((frame, index) => ({
+          relativePath: frame.relativePath,
+          text: index === 0 ? '来自 /Users/alice/Desktop/private.png' : '安全演示画面',
+        })),
+      }),
+    }),
+    /隐私|macos-home|敏感/,
+  );
+
+  const markdownFixture = await createDeliveryFixture();
+  await writeFile(
+    path.join(markdownFixture.artifactDir, markdownFixture.markdownFiles[0]!),
+    '联系 alice@example.com',
+  );
+  await assert.rejects(
+    validateDelivery({ ...markdownFixture, probeMediaFile }),
+    /隐私|email|敏感/,
+  );
+
+  const sourceFixture = await createDeliveryFixture();
+  await writeFile(
+    path.join(sourceFixture.artifactDir, sourceFixture.sourceTextFiles[0]!),
+    '<main>https://github.com/example/private</main>',
+  );
+  await assert.rejects(
+    validateDelivery({ ...sourceFixture, probeMediaFile }),
+    /隐私|forbidden-domain|敏感/,
+  );
+
+  const legacyOcrFixture = await createDeliveryFixture();
+  const legacyOcrPath = 'intermediate/legacy-ocr.txt';
+  await writeFile(path.join(legacyOcrFixture.artifactDir, legacyOcrPath), 'Bearer abcdefghijklmnop');
+  await assert.rejects(
+    validateDelivery({
+      ...legacyOcrFixture,
+      probeMediaFile,
+      ocrTextFiles: [legacyOcrPath],
+    }),
+    /隐私|bearer-token|敏感/,
+  );
+
+  const objectFixture = await createDeliveryFixture();
+  await assert.rejects(
+    validateDelivery({
+      ...objectFixture,
+      probeMediaFile,
+      privacyObjects: [{ source: 'demo-fixtures', value: { email: 'alice@example.com' } }],
+    }),
+    /隐私|email|敏感/,
+  );
+});
+
+test('完整交付验证拒绝空文件、SRT 时间轴漂移和敏感日志', async () => {
+  const emptyFixture = await createDeliveryFixture();
+  await writeFile(path.join(emptyFixture.artifactDir, 'work-review-demo-en.srt'), '');
+  await assert.rejects(
+    validateDelivery({
+      ...emptyFixture,
+      probeMediaFile: async (filePath) => filePath.includes('9x16')
+        ? validProbe(1080, 1920)
+        : validProbe(),
+    }),
+    /非空|为空/,
+  );
+
+  const driftFixture = await createDeliveryFixture();
+  const englishPath = path.join(driftFixture.artifactDir, 'work-review-demo-en.srt');
+  const english = await readFile(englishPath, 'utf8');
+  await writeFile(englishPath, english.replace('00:00:07,350', '00:00:07,450'));
+  await assert.rejects(
+    validateDelivery({
+      ...driftFixture,
+      probeMediaFile: async (filePath) => filePath.includes('9x16')
+        ? validProbe(1080, 1920)
+        : validProbe(),
+    }),
+    /时间轴.*一致|漂移/,
+  );
+
+  const privacyFixture = await createDeliveryFixture();
+  await writeFile(
+    path.join(privacyFixture.artifactDir, privacyFixture.logFiles[0]),
+    '截图来自 /Users/alice/Desktop/private.png',
+  );
+  await assert.rejects(
+    validateDelivery({
+      ...privacyFixture,
+      probeMediaFile: async (filePath) => filePath.includes('9x16')
+        ? validProbe(1080, 1920)
+        : validProbe(),
+    }),
+    /隐私|macos-home|敏感/,
+  );
+});
+
+test('交付路径不得逃逸产物目录，日志和虚拟 Markdown 都必须提供', async () => {
+  const fixture = await createDeliveryFixture();
+  const probeMediaFile = async (filePath: string) => filePath.includes('9x16')
+    ? validProbe(1080, 1920)
+    : validProbe();
+
+  await assert.rejects(
+    validateDelivery({ ...fixture, logFiles: ['../outside.log'], probeMediaFile }),
+    /产物目录|相对路径/,
+  );
+  await assert.rejects(
+    validateDelivery({ ...fixture, logFiles: [], probeMediaFile }),
+    /日志/,
+  );
+  await assert.rejects(
+    validateDelivery({ ...fixture, markdownFiles: [], probeMediaFile }),
+    /Markdown/,
+  );
+  await assert.rejects(
+    validateDelivery({ ...fixture, sourceTextFiles: [], probeMediaFile }),
+    /源码|HTML/,
+  );
+  await assert.rejects(
+    validateDelivery({ ...fixture, privacyObjects: [], probeMediaFile }),
+    /夹具|隐私扫描对象/,
+  );
+});
+
+test('纯函数生成稳定 manifest、SHA-256 与校验和文本', () => {
+  assert.equal(
+    sha256Hex('Work Review'),
+    '9eb95b78076ede5533a0ee0824633e1180a59bfdbd146bef4fc278a6bd2abd78',
+  );
+  assert.equal(
+    formatSha256Sums([
+      { relativePath: 'z.txt', sha256: 'b'.repeat(64) },
+      { relativePath: 'a.txt', sha256: 'a'.repeat(64) },
+    ]),
+    `${'a'.repeat(64)}  a.txt\n${'b'.repeat(64)}  z.txt\n`,
+  );
+
+  const manifest = buildDeliveryManifest({
+    version: '1.1.1-demo',
+    builtAt: '2026-08-12T12:00:00.000Z',
+    gitCommit: 'abc1234',
+    media: {
+      '16x9': validateMediaArtifact({
+        aspect: '16x9',
+        relativePath: 'work-review-demo-16x9.mp4',
+        sizeBytes: 10,
+        probe: validProbe(),
+      }),
+      '9x16': validateMediaArtifact({
+        aspect: '9x16',
+        relativePath: 'work-review-demo-9x16.mp4',
+        sizeBytes: 20,
+        probe: validProbe(1080, 1920),
+      }),
+    },
+    files: [{ relativePath: 'work-review-demo-zh.srt', sizeBytes: 99, sha256: 'a'.repeat(64) }],
+    manualChecks: ['检查关键帧'],
+  });
+
+  assert.equal(manifest.schemaVersion, 1);
+  assert.equal(manifest.media['16x9'].resolution, '1920x1080');
+  assert.equal(manifest.media['9x16'].frameCount, 2550);
+  assert.equal(manifest.files[0]?.sizeBytes, 99);
+});
+
+test('写入 manifest.json 与 SHA256SUMS，并可从文件入口复验完整性', async () => {
+  const fixture = await createDeliveryFixture();
+  const options = {
+    ...fixture,
+    probeMediaFile: async (filePath: string) => filePath.includes('9x16')
+      ? validProbe(1080, 1920)
+      : validProbe(),
+  };
+  const validation = await validateDelivery(options);
+  const written = await writeManifest({
+    artifactDir: fixture.artifactDir,
+    version: '1.1.1-demo',
+    builtAt: '2026-08-12T12:00:00.000Z',
+    gitCommit: 'abc1234',
+    validation,
+  });
+
+  assert.equal((await stat(written.manifestPath)).size > 0, true);
+  assert.equal((await stat(written.sha256SumsPath)).size > 0, true);
+  const manifest = JSON.parse(await readFile(written.manifestPath, 'utf8')) as {
+    version: string;
+    media: { '16x9': { durationSeconds: number; videoCodec: string } };
+  };
+  assert.equal(manifest.version, '1.1.1-demo');
+  assert.equal(manifest.media['16x9'].durationSeconds, 85);
+  assert.equal(manifest.media['16x9'].videoCodec, 'h264');
+
+  const verified = await validateDelivery({ ...options, requireIntegrityFiles: true });
+  assert.equal(verified.integrityVerified, true);
+
+  await writeFile(path.join(fixture.artifactDir, 'work-review-demo-zh.srt'), SAFE_SRT.replace('今日完成导出流程', '今日完成安全导出流程').replace('当天轨迹', '当日轨迹'));
+  await assert.rejects(
+    validateDelivery({ ...options, requireIntegrityFiles: true }),
+    /SHA-256|校验和/,
+  );
+});
+
+test('原子写使用不可预测临时路径，不能跟随旧式可预测路径上的符号链接', async () => {
+  const fixture = await createDeliveryFixture();
+  const validation = await validateDelivery({
+    ...fixture,
+    probeMediaFile: async (filePath) => filePath.includes('9x16')
+      ? validProbe(1080, 1920)
+      : validProbe(),
+  });
+  const victimPath = path.join(fixture.artifactDir, 'victim.txt');
+  const predictableTemporaryPath = path.join(
+    fixture.artifactDir,
+    `manifest.json.tmp-${process.pid}`,
+  );
+  await writeFile(victimPath, '不得修改');
+  await symlink(victimPath, predictableTemporaryPath);
+
+  const written = await writeManifest({
+    artifactDir: fixture.artifactDir,
+    version: '1.1.1-demo',
+    builtAt: '2026-08-12T12:00:00.000Z',
+    gitCommit: 'abc1234',
+    validation,
+  });
+
+  assert.equal(await readFile(victimPath, 'utf8'), '不得修改');
+  assert.equal((await lstat(written.manifestPath)).isSymbolicLink(), false);
+});
+
+test('原子写通过 wx 独占创建拒绝已存在的随机临时路径', async () => {
+  const fixture = await createDeliveryFixture();
+  const validation = await validateDelivery({
+    ...fixture,
+    probeMediaFile: async (filePath) => filePath.includes('9x16')
+      ? validProbe(1080, 1920)
+      : validProbe(),
+  });
+  const collisionToken = '00000000-0000-4000-8000-000000000000';
+  const victimPath = path.join(fixture.artifactDir, 'collision-victim.txt');
+  const occupiedTemporaryPath = path.join(
+    fixture.artifactDir,
+    `manifest.json.tmp-${collisionToken}`,
+  );
+  await writeFile(victimPath, '不得覆盖');
+  await symlink(victimPath, occupiedTemporaryPath);
+
+  const originalRandomUuid = crypto.randomUUID;
+  crypto.randomUUID = () => collisionToken;
+  syncBuiltinESMExports();
+  try {
+    await assert.rejects(
+      writeManifest({
+        artifactDir: fixture.artifactDir,
+        version: '1.1.1-demo',
+        builtAt: '2026-08-12T12:00:00.000Z',
+        gitCommit: 'abc1234',
+        validation,
+      }),
+      (error: NodeJS.ErrnoException) => error.code === 'EEXIST',
+    );
+  } finally {
+    crypto.randomUUID = originalRandomUuid;
+    syncBuiltinESMExports();
+  }
+
+  assert.equal(await readFile(victimPath, 'utf8'), '不得覆盖');
+  assert.equal((await lstat(occupiedTemporaryPath)).isSymbolicLink(), true);
+});
+
+test('原子写重命名失败后清理本次创建的临时文件', async () => {
+  const fixture = await createDeliveryFixture();
+  const validation = await validateDelivery({
+    ...fixture,
+    probeMediaFile: async (filePath) => filePath.includes('9x16')
+      ? validProbe(1080, 1920)
+      : validProbe(),
+  });
+  await mkdir(path.join(fixture.artifactDir, 'SHA256SUMS'));
+
+  await assert.rejects(writeManifest({
+    artifactDir: fixture.artifactDir,
+    version: '1.1.1-demo',
+    builtAt: '2026-08-12T12:00:00.000Z',
+    gitCommit: 'abc1234',
+    validation,
+  }));
+
+  const leakedTemporaryFiles = (await readdir(fixture.artifactDir))
+    .filter((name) => name.startsWith('SHA256SUMS.tmp-'));
+  assert.deepEqual(leakedTemporaryFiles, []);
+});

--- a/scripts/product-demo/validate.ts
+++ b/scripts/product-demo/validate.ts
@@ -1,0 +1,956 @@
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  lstat,
+  open,
+  readFile,
+  realpath,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+  probeMedia,
+  type MediaProbe,
+} from './ffmpeg.ts';
+import {
+  assertNoSensitiveContent,
+  scanDemoObject,
+  scanSensitiveText,
+  type PrivacyFinding,
+} from './privacy.ts';
+import {
+  DEMO_DURATION_SECONDS,
+  DEMO_FPS,
+  DEMO_TOTAL_FRAMES,
+  STORYBOARD,
+} from './storyboard.ts';
+import type { DemoAspect, StoryboardSceneId } from './types.ts';
+
+const FRAME_TOLERANCE_SECONDS = 1 / DEMO_FPS;
+const RATE_TOLERANCE = 1e-6;
+const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+const KEYFRAME_PHASES = ['start', 'action', 'end'] as const;
+
+const MEDIA_FILES: Readonly<Record<DemoAspect, string>> = {
+  '16x9': 'work-review-demo-16x9.mp4',
+  '9x16': 'work-review-demo-9x16.mp4',
+};
+
+const SUBTITLE_FILES = [
+  'work-review-demo-zh.srt',
+  'work-review-demo-en.srt',
+  'work-review-demo-zh-en.srt',
+] as const;
+
+const COVER_FILES: Readonly<Record<DemoAspect, string>> = {
+  '16x9': 'work-review-demo-cover-16x9.png',
+  '9x16': 'work-review-demo-cover-9x16.png',
+};
+
+const TARGET_DIMENSIONS: Readonly<Record<DemoAspect, { width: number; height: number }>> = {
+  '16x9': { width: 1920, height: 1080 },
+  '9x16': { width: 1080, height: 1920 },
+};
+
+export interface MediaArtifactInput {
+  aspect: DemoAspect;
+  relativePath: string;
+  sizeBytes: number;
+  probe: MediaProbe;
+}
+
+export interface ValidatedMediaArtifact {
+  aspect: DemoAspect;
+  relativePath: string;
+  sizeBytes: number;
+  width: number;
+  height: number;
+  resolution: string;
+  durationSeconds: number;
+  frameRate: number;
+  frameCount: number;
+  videoCodec: 'h264';
+  audioCodec: 'aac';
+  pixelFormat: 'yuv420p';
+}
+
+export interface ParsedSubtitleCue {
+  index: number;
+  startMilliseconds: number;
+  endMilliseconds: number;
+  text: string;
+}
+
+export interface ValidatedSubtitleArtifact {
+  relativePath: string;
+  cueCount: number;
+  timelineMilliseconds: ReadonlyArray<readonly [number, number]>;
+}
+
+export interface DeliveryFileRecord {
+  relativePath: string;
+  sizeBytes: number;
+  sha256: string;
+}
+
+export interface PrivacyObjectInput {
+  source: string;
+  value: unknown;
+}
+
+export type KeyframeOcrPhase = typeof KEYFRAME_PHASES[number];
+
+/** 自动 OCR 引擎需要处理的真实关键帧；绝对路径仅在运行期传递，不写入交付清单。 */
+export interface KeyframeOcrFrame {
+  aspect: DemoAspect;
+  scene: StoryboardSceneId;
+  phase: KeyframeOcrPhase;
+  relativePath: string;
+  absolutePath: string;
+  imageBytes: Uint8Array;
+}
+
+export interface KeyframeOcrEvidence {
+  relativePath: string;
+  text: string;
+}
+
+export type KeyframeOcrRunResult =
+  | {
+      available: true;
+      engine: string;
+      evidence: readonly KeyframeOcrEvidence[];
+    }
+  | {
+      available: false;
+      reason: string;
+    };
+
+export type KeyframeOcrRunner = (
+  frames: readonly KeyframeOcrFrame[],
+) => Promise<KeyframeOcrRunResult>;
+
+export interface ValidateDeliveryOptions {
+  artifactDir: string;
+  logFiles: readonly string[];
+  markdownFiles: readonly string[];
+  sourceTextFiles?: readonly string[];
+  ocrTextFiles?: readonly string[];
+  privacyObjects?: readonly PrivacyObjectInput[];
+  runKeyframeOcr?: KeyframeOcrRunner;
+  probeMediaFile?: (filePath: string) => Promise<MediaProbe>;
+  requireIntegrityFiles?: boolean;
+}
+
+export interface DeliveryValidationResult {
+  artifactDir: string;
+  files: DeliveryFileRecord[];
+  media: Record<DemoAspect, ValidatedMediaArtifact>;
+  subtitles: Record<string, ValidatedSubtitleArtifact>;
+  covers: Record<DemoAspect, { width: number; height: number }>;
+  subtitleTimelineMilliseconds: ReadonlyArray<readonly [number, number]>;
+  manualChecks: string[];
+  keyframeOcr: {
+    engine: string;
+    evidenceCount: number;
+  };
+  integrityVerified: boolean;
+}
+
+export interface DeliveryManifestInput {
+  version: string;
+  builtAt: string;
+  gitCommit: string;
+  media: Record<DemoAspect, ValidatedMediaArtifact>;
+  files: readonly DeliveryFileRecord[];
+  manualChecks: readonly string[];
+}
+
+export interface DeliveryManifest {
+  schemaVersion: 1;
+  version: string;
+  builtAt: string;
+  gitCommit: string;
+  media: Record<DemoAspect, {
+    path: string;
+    resolution: string;
+    width: number;
+    height: number;
+    durationSeconds: number;
+    frameRate: number;
+    frameCount: number;
+    videoCodec: string;
+    audioCodec: string;
+    pixelFormat: string;
+    sizeBytes: number;
+  }>;
+  files: DeliveryFileRecord[];
+  manualChecks: string[];
+}
+
+export interface WriteManifestOptions {
+  artifactDir: string;
+  version: string;
+  builtAt: string;
+  gitCommit: string;
+  validation: DeliveryValidationResult;
+}
+
+export interface WrittenManifestPaths {
+  manifestPath: string;
+  sha256SumsPath: string;
+}
+
+interface LoadedFile {
+  relativePath: string;
+  absolutePath: string;
+  bytes: Buffer;
+  sizeBytes: number;
+}
+
+function assertNonEmptyString(value: string, label: string): void {
+  if (!value.trim()) throw new Error(`${label}不得为空`);
+}
+
+function approximatelyEqual(left: number, right: number, tolerance: number): boolean {
+  return Number.isFinite(left)
+    && Number.isFinite(right)
+    && Math.abs(left - right) <= tolerance;
+}
+
+function requiredFiniteNumber(value: number | null, label: string): number {
+  if (value === null || !Number.isFinite(value)) throw new Error(`${label}缺失或无效`);
+  return value;
+}
+
+function requiredPositiveInteger(value: number | null, label: string): number {
+  if (value === null || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`${label}缺失或无效`);
+  }
+  return value;
+}
+
+function assertExpectedCodec(
+  actual: string | null,
+  expected: 'h264' | 'aac' | 'yuv420p',
+  label: string,
+): void {
+  if (actual?.toLowerCase() !== expected) {
+    const displayExpected = expected === 'h264' ? 'H.264' : expected === 'aac' ? 'AAC' : expected;
+    throw new Error(`${label}必须为 ${displayExpected}，实际为 ${actual ?? '缺失'}`);
+  }
+}
+
+/** 验证单个成片的发布媒体规格，并返回可写入清单的规范化数据。 */
+export function validateMediaArtifact(input: MediaArtifactInput): ValidatedMediaArtifact {
+  if (!Number.isInteger(input.sizeBytes) || input.sizeBytes <= 0) {
+    throw new Error(`媒体文件 ${input.relativePath} 必须存在且非空`);
+  }
+
+  const expected = TARGET_DIMENSIONS[input.aspect];
+  const { probe } = input;
+  const formatNames = new Set(
+    (probe.formatName ?? '').toLowerCase().split(',').map((value) => value.trim()).filter(Boolean),
+  );
+  if (!formatNames.has('mp4')) {
+    throw new Error(`媒体文件 ${input.relativePath} 必须使用 MP4 容器`);
+  }
+  if (!probe.video) throw new Error(`媒体文件 ${input.relativePath} 缺少视频轨`);
+  if (!probe.audio) throw new Error(`媒体文件 ${input.relativePath} 缺少 AAC 音轨`);
+
+  const durationSeconds = requiredFiniteNumber(probe.durationSeconds, '容器时长');
+  if (!approximatelyEqual(durationSeconds, DEMO_DURATION_SECONDS, FRAME_TOLERANCE_SECONDS)) {
+    throw new Error(
+      `媒体文件 ${input.relativePath} 时长必须为 ${DEMO_DURATION_SECONDS} 秒（允许一帧误差），实际为 ${durationSeconds} 秒`,
+    );
+  }
+
+  const videoDurationSeconds = requiredFiniteNumber(probe.video.durationSeconds, '视频流时长');
+  if (!approximatelyEqual(videoDurationSeconds, DEMO_DURATION_SECONDS, FRAME_TOLERANCE_SECONDS)) {
+    throw new Error(
+      `视频流时长必须为 ${DEMO_DURATION_SECONDS} 秒（允许一帧误差），实际为 ${videoDurationSeconds} 秒`,
+    );
+  }
+
+  const width = requiredPositiveInteger(probe.video.width, '视频宽度');
+  const height = requiredPositiveInteger(probe.video.height, '视频高度');
+  if (width !== expected.width || height !== expected.height) {
+    throw new Error(
+      `${input.aspect} 媒体分辨率必须为 ${expected.width}×${expected.height}，实际为 ${width}×${height}`,
+    );
+  }
+
+  const nominalFrameRate = requiredFiniteNumber(probe.video.frameRate, '视频标称帧率');
+  const averageFrameRate = requiredFiniteNumber(probe.video.averageFrameRate, '视频平均帧率');
+  if (!approximatelyEqual(nominalFrameRate, DEMO_FPS, RATE_TOLERANCE)) {
+    throw new Error(`视频标称帧率必须为恒定 ${DEMO_FPS}fps，实际为 ${nominalFrameRate}fps`);
+  }
+  if (!approximatelyEqual(averageFrameRate, DEMO_FPS, RATE_TOLERANCE)
+    || !approximatelyEqual(nominalFrameRate, averageFrameRate, RATE_TOLERANCE)) {
+    throw new Error(`视频平均帧率必须证明恒定 ${DEMO_FPS}fps，实际为 ${averageFrameRate}fps`);
+  }
+
+  if (probe.video.frameCount === null) {
+    throw new Error('视频缺少准确帧数；必须使用 ffprobe -count_frames 获取 nb_read_frames');
+  }
+  const frameCount = requiredPositiveInteger(probe.video.frameCount, '视频帧数');
+  if (frameCount !== DEMO_TOTAL_FRAMES) {
+    throw new Error(`视频必须包含 ${DEMO_TOTAL_FRAMES} 帧，实际为 ${frameCount} 帧`);
+  }
+
+  assertExpectedCodec(probe.video.codec, 'h264', '视频编码');
+  assertExpectedCodec(probe.audio.codec, 'aac', '音频编码');
+  assertExpectedCodec(probe.video.pixelFormat, 'yuv420p', '像素格式');
+
+  const audioDurationSeconds = requiredFiniteNumber(probe.audio.durationSeconds, '音频时长');
+  if (!approximatelyEqual(audioDurationSeconds, DEMO_DURATION_SECONDS, FRAME_TOLERANCE_SECONDS)) {
+    throw new Error(
+      `音频时长必须为 ${DEMO_DURATION_SECONDS} 秒（允许一帧误差），实际为 ${audioDurationSeconds} 秒`,
+    );
+  }
+  const allowedEnd = videoDurationSeconds + FRAME_TOLERANCE_SECONDS;
+  if (audioDurationSeconds > allowedEnd) {
+    throw new Error(
+      `音频结尾不得超出视频画面，音频为 ${audioDurationSeconds} 秒，画面为 ${durationSeconds} 秒`,
+    );
+  }
+
+  return {
+    aspect: input.aspect,
+    relativePath: input.relativePath,
+    sizeBytes: input.sizeBytes,
+    width,
+    height,
+    resolution: `${width}x${height}`,
+    durationSeconds,
+    frameRate: averageFrameRate,
+    frameCount,
+    videoCodec: 'h264',
+    audioCodec: 'aac',
+    pixelFormat: 'yuv420p',
+  };
+}
+
+function parseSrtTimestamp(value: string, source: string): number {
+  const match = /^(\d{2,}):(\d{2}):(\d{2}),(\d{3})$/u.exec(value);
+  if (!match) throw new Error(`SRT ${source} 包含无效时间码：${value}`);
+
+  const [, hoursText, minutesText, secondsText, millisecondsText] = match;
+  const hours = Number(hoursText);
+  const minutes = Number(minutesText);
+  const seconds = Number(secondsText);
+  const milliseconds = Number(millisecondsText);
+  if (minutes > 59 || seconds > 59) {
+    throw new Error(`SRT ${source} 包含越界时间码：${value}`);
+  }
+  return (((hours * 60) + minutes) * 60 + seconds) * 1000 + milliseconds;
+}
+
+/** 严格解析 SRT；返回时间线供三语文件做逐条一致性比对。 */
+export function parseSrtArtifact(content: string, source: string): ParsedSubtitleCue[] {
+  assertNonEmptyString(source, 'SRT 来源');
+  if (!content.trim()) throw new Error(`SRT ${source} 必须存在且非空`);
+
+  const normalized = content.replaceAll('\r\n', '\n').replaceAll('\r', '\n').trim();
+  const blocks = normalized.split(/\n{2,}/u);
+  const cues: ParsedSubtitleCue[] = [];
+
+  for (const [position, block] of blocks.entries()) {
+    const lines = block.split('\n');
+    if (lines.length < 3) throw new Error(`SRT ${source} 第 ${position + 1} 段格式无效`);
+
+    const index = Number(lines[0]);
+    if (!Number.isInteger(index) || index !== position + 1) {
+      throw new Error(`SRT ${source} 序号必须从 1 连续递增`);
+    }
+
+    const timing = /^(\S+)\s+-->\s+(\S+)$/u.exec(lines[1] ?? '');
+    if (!timing) throw new Error(`SRT ${source} 第 ${index} 条时间码格式无效`);
+    const startMilliseconds = parseSrtTimestamp(timing[1], source);
+    const endMilliseconds = parseSrtTimestamp(timing[2], source);
+    const text = lines.slice(2).join('\n').trim();
+    if (!text) throw new Error(`SRT ${source} 第 ${index} 条字幕文本为空`);
+    if (endMilliseconds <= startMilliseconds) {
+      throw new Error(`SRT ${source} 第 ${index} 条时间轴倒序或时长无效`);
+    }
+    if (endMilliseconds > DEMO_DURATION_SECONDS * 1000) {
+      throw new Error(`SRT ${source} 第 ${index} 条超过 ${DEMO_DURATION_SECONDS} 秒视频边界`);
+    }
+
+    const previous = cues.at(-1);
+    if (previous && startMilliseconds < previous.endMilliseconds) {
+      throw new Error(`SRT ${source} 第 ${index} 条与上一条重叠或倒序`);
+    }
+
+    cues.push({ index, startMilliseconds, endMilliseconds, text });
+  }
+
+  return cues;
+}
+
+export function validateSubtitleArtifact(
+  content: string,
+  relativePath: string,
+): ValidatedSubtitleArtifact {
+  const cues = parseSrtArtifact(content, relativePath);
+  return {
+    relativePath,
+    cueCount: cues.length,
+    timelineMilliseconds: cues.map(
+      (cue) => [cue.startMilliseconds, cue.endMilliseconds] as const,
+    ),
+  };
+}
+
+/** 从 PNG IHDR 读取画布尺寸，不依赖图像解码器。 */
+export function parsePngDimensions(bytes: Uint8Array): { width: number; height: number } {
+  const buffer = Buffer.from(bytes);
+  if (buffer.length < 24
+    || !buffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)
+    || buffer.toString('ascii', 12, 16) !== 'IHDR') {
+    throw new Error('封面文件不是有效的 PNG，或缺少 IHDR');
+  }
+  const width = buffer.readUInt32BE(16);
+  const height = buffer.readUInt32BE(20);
+  if (width <= 0 || height <= 0) throw new Error('PNG 封面尺寸无效');
+  return { width, height };
+}
+
+export function validateCoverArtifact(
+  bytes: Uint8Array,
+  aspect: DemoAspect,
+  relativePath: string,
+): { width: number; height: number } {
+  if (bytes.byteLength === 0) throw new Error(`封面 ${relativePath} 必须存在且非空`);
+  const dimensions = parsePngDimensions(bytes);
+  const expected = TARGET_DIMENSIONS[aspect];
+  if (dimensions.width !== expected.width || dimensions.height !== expected.height) {
+    throw new Error(
+      `${aspect} 封面必须为 ${expected.width}×${expected.height}，实际为 ${dimensions.width}×${dimensions.height}`,
+    );
+  }
+  return dimensions;
+}
+
+export function sha256Hex(value: string | Uint8Array): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function validateChecksumRecord(record: Pick<DeliveryFileRecord, 'relativePath' | 'sha256'>): void {
+  assertNonEmptyString(record.relativePath, '校验和相对路径');
+  if (record.relativePath.includes('\n') || record.relativePath.includes('\r')) {
+    throw new Error('校验和相对路径不得包含换行');
+  }
+  if (!/^[0-9a-f]{64}$/u.test(record.sha256)) {
+    throw new Error(`文件 ${record.relativePath} 的 SHA-256 无效`);
+  }
+}
+
+export function formatSha256Sums(
+  records: readonly Pick<DeliveryFileRecord, 'relativePath' | 'sha256'>[],
+): string {
+  const seen = new Set<string>();
+  const sorted = [...records].sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+  for (const record of sorted) {
+    validateChecksumRecord(record);
+    if (seen.has(record.relativePath)) throw new Error(`校验和包含重复路径：${record.relativePath}`);
+    seen.add(record.relativePath);
+  }
+  return sorted.map((record) => `${record.sha256}  ${record.relativePath}\n`).join('');
+}
+
+function manifestMedia(media: ValidatedMediaArtifact): DeliveryManifest['media'][DemoAspect] {
+  return {
+    path: media.relativePath,
+    resolution: media.resolution,
+    width: media.width,
+    height: media.height,
+    durationSeconds: media.durationSeconds,
+    frameRate: media.frameRate,
+    frameCount: media.frameCount,
+    videoCodec: media.videoCodec,
+    audioCodec: media.audioCodec,
+    pixelFormat: media.pixelFormat,
+    sizeBytes: media.sizeBytes,
+  };
+}
+
+/** 构建稳定、可序列化且不读取环境状态的交付清单。 */
+export function buildDeliveryManifest(input: DeliveryManifestInput): DeliveryManifest {
+  assertNonEmptyString(input.version, '版本');
+  assertNonEmptyString(input.gitCommit, 'Git commit');
+  if (!Number.isFinite(Date.parse(input.builtAt))) throw new Error('构建时间必须是有效 ISO 时间');
+
+  const files = [...input.files]
+    .sort((left, right) => left.relativePath.localeCompare(right.relativePath))
+    .map((file) => ({ ...file }));
+  for (const file of files) {
+    validateChecksumRecord(file);
+    if (!Number.isInteger(file.sizeBytes) || file.sizeBytes <= 0) {
+      throw new Error(`清单文件 ${file.relativePath} 必须非空`);
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    version: input.version,
+    builtAt: input.builtAt,
+    gitCommit: input.gitCommit,
+    media: {
+      '16x9': manifestMedia(input.media['16x9']),
+      '9x16': manifestMedia(input.media['9x16']),
+    },
+    files,
+    manualChecks: [...input.manualChecks],
+  };
+}
+
+function isPathInside(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}
+
+function resolveArtifactPath(artifactDir: string, relativePath: string): string {
+  assertNonEmptyString(relativePath, '交付文件相对路径');
+  if (path.isAbsolute(relativePath)) throw new Error(`交付文件必须使用相对路径：${relativePath}`);
+  const absoluteRoot = path.resolve(artifactDir);
+  const absolutePath = path.resolve(absoluteRoot, relativePath);
+  if (!isPathInside(absoluteRoot, absolutePath) || absolutePath === absoluteRoot) {
+    throw new Error(`交付文件路径不得逃逸产物目录：${relativePath}`);
+  }
+  return absolutePath;
+}
+
+async function loadRequiredFile(artifactDir: string, relativePath: string): Promise<LoadedFile> {
+  const absolutePath = resolveArtifactPath(artifactDir, relativePath);
+  let fileInfo;
+  try {
+    fileInfo = await lstat(absolutePath);
+  } catch (error) {
+    throw new Error(`缺少交付文件 ${relativePath}：${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (fileInfo.isSymbolicLink()) throw new Error(`交付文件不得是符号链接：${relativePath}`);
+  if (!fileInfo.isFile()) throw new Error(`交付路径不是普通文件：${relativePath}`);
+  if (fileInfo.size <= 0) throw new Error(`交付文件 ${relativePath} 必须存在且非空`);
+
+  const [rootRealPath, fileRealPath] = await Promise.all([realpath(artifactDir), realpath(absolutePath)]);
+  if (!isPathInside(rootRealPath, fileRealPath)) {
+    throw new Error(`交付文件真实路径逃逸产物目录：${relativePath}`);
+  }
+
+  const bytes = await readFile(absolutePath);
+  if (bytes.length <= 0) throw new Error(`交付文件 ${relativePath} 读取后为空`);
+  return {
+    relativePath,
+    absolutePath,
+    bytes,
+    sizeBytes: bytes.length,
+  };
+}
+
+function fileRecord(file: LoadedFile): DeliveryFileRecord {
+  return {
+    relativePath: file.relativePath,
+    sizeBytes: file.sizeBytes,
+    sha256: sha256Hex(file.bytes),
+  };
+}
+
+function uniquePaths(paths: readonly string[], label: string): string[] {
+  if (paths.length === 0) throw new Error(`交付验证必须提供至少一个${label}`);
+  const unique = [...new Set(paths)];
+  if (unique.length !== paths.length) throw new Error(`${label}路径不得重复`);
+  return unique;
+}
+
+function optionalUniquePaths(paths: readonly string[] | undefined, label: string): string[] {
+  const values = paths ?? [];
+  const unique = [...new Set(values)];
+  if (unique.length !== values.length) throw new Error(`${label}路径不得重复`);
+  return unique;
+}
+
+function expectedKeyframeDescriptors(): Array<{
+  aspect: DemoAspect;
+  scene: StoryboardSceneId;
+  phase: KeyframeOcrPhase;
+  relativePath: string;
+}> {
+  return (['16x9', '9x16'] as const).flatMap((aspect) => (
+    STORYBOARD.flatMap((scene) => (
+      KEYFRAME_PHASES.map((phase) => ({
+        aspect,
+        scene: scene.id,
+        phase,
+        relativePath: `intermediate/${aspect}/${scene.id}-${phase}.png`,
+      }))
+    ))
+  ));
+}
+
+function assertKeyframeOcrEvidence(
+  result: KeyframeOcrRunResult,
+  frames: readonly KeyframeOcrFrame[],
+): { engine: string; evidence: KeyframeOcrEvidence[] } {
+  if (!result || typeof result !== 'object') {
+    throw new Error('自动 OCR 返回了无效结果，无法验证关键帧隐私');
+  }
+  if (!result.available) {
+    const reason = typeof result.reason === 'string' && result.reason.trim()
+      ? result.reason.trim()
+      : 'OCR 引擎未提供原因';
+    throw new Error(`自动 OCR 不可用，交付已阻断：${reason}`);
+  }
+  if (typeof result.engine !== 'string' || !result.engine.trim()) {
+    throw new Error('自动 OCR 未报告有效引擎名称，无法把结果作为交付证据');
+  }
+  if (!Array.isArray(result.evidence)) {
+    throw new Error('自动 OCR 未返回关键帧 OCR 证据数组');
+  }
+
+  const expectedPaths = new Set(frames.map((frame) => frame.relativePath));
+  const evidenceByPath = new Map<string, KeyframeOcrEvidence>();
+  for (const item of result.evidence) {
+    if (!item || typeof item !== 'object'
+      || typeof item.relativePath !== 'string'
+      || typeof item.text !== 'string') {
+      throw new Error('自动 OCR 返回了无效证据；每项必须包含关键帧相对路径与真实 OCR 文本');
+    }
+    if (!expectedPaths.has(item.relativePath)) {
+      throw new Error(`自动 OCR 返回了未知关键帧证据：${item.relativePath}`);
+    }
+    if (evidenceByPath.has(item.relativePath)) {
+      throw new Error(`关键帧 OCR 证据路径重复：${item.relativePath}`);
+    }
+    evidenceByPath.set(item.relativePath, item);
+  }
+
+  for (const frame of frames) {
+    if (!evidenceByPath.has(frame.relativePath)) {
+      throw new Error(`关键帧 OCR 证据缺失：${frame.relativePath}`);
+    }
+  }
+  return {
+    engine: result.engine.trim(),
+    evidence: frames.map((frame) => evidenceByPath.get(frame.relativePath)!),
+  };
+}
+
+function sameTimeline(
+  left: ReadonlyArray<readonly [number, number]>,
+  right: ReadonlyArray<readonly [number, number]>,
+): boolean {
+  return left.length === right.length && left.every(
+    (range, index) => range[0] === right[index]?.[0] && range[1] === right[index]?.[1],
+  );
+}
+
+function parseSha256Sums(content: string): Map<string, string> {
+  const entries = new Map<string, string>();
+  const lines = content.replaceAll('\r\n', '\n').trim().split('\n');
+  for (const line of lines) {
+    const match = /^([0-9a-f]{64})  (.+)$/u.exec(line);
+    if (!match) throw new Error(`SHA256SUMS 包含无效行：${line}`);
+    const [, hash, relativePath] = match;
+    validateChecksumRecord({ relativePath, sha256: hash });
+    if (entries.has(relativePath)) throw new Error(`SHA256SUMS 包含重复路径：${relativePath}`);
+    entries.set(relativePath, hash);
+  }
+  return entries;
+}
+
+function parseManifest(content: string): DeliveryManifest {
+  let value: unknown;
+  try {
+    value = JSON.parse(content);
+  } catch (error) {
+    throw new Error(`manifest.json 不是有效 JSON：${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('manifest.json 顶层必须是对象');
+  }
+  const candidate = value as Partial<DeliveryManifest>;
+  if (candidate.schemaVersion !== 1 || !Array.isArray(candidate.files) || !candidate.media) {
+    throw new Error('manifest.json 缺少受支持的清单结构');
+  }
+  return candidate as DeliveryManifest;
+}
+
+function assertManifestMatches(
+  manifest: DeliveryManifest,
+  files: readonly DeliveryFileRecord[],
+  media: Record<DemoAspect, ValidatedMediaArtifact>,
+): void {
+  const expectedFiles = new Map(files.map((file) => [file.relativePath, file]));
+  if (manifest.files.length !== expectedFiles.size) {
+    throw new Error('manifest.json 文件清单数量与当前交付不一致');
+  }
+  for (const manifestFile of manifest.files) {
+    const current = expectedFiles.get(manifestFile.relativePath);
+    if (!current
+      || current.sizeBytes !== manifestFile.sizeBytes
+      || current.sha256 !== manifestFile.sha256) {
+      throw new Error(`manifest.json 的 SHA-256 或大小与当前文件不一致：${manifestFile.relativePath}`);
+    }
+  }
+
+  for (const aspect of ['16x9', '9x16'] as const) {
+    const listed = manifest.media[aspect];
+    const current = media[aspect];
+    if (!listed
+      || listed.path !== current.relativePath
+      || listed.resolution !== current.resolution
+      || listed.durationSeconds !== current.durationSeconds
+      || listed.frameRate !== current.frameRate
+      || listed.frameCount !== current.frameCount
+      || listed.videoCodec !== current.videoCodec
+      || listed.audioCodec !== current.audioCodec
+      || listed.pixelFormat !== current.pixelFormat
+      || listed.sizeBytes !== current.sizeBytes) {
+      throw new Error(`manifest.json 的 ${aspect} 媒体规格与当前文件不一致`);
+    }
+  }
+}
+
+async function verifyIntegrityFiles(
+  artifactDir: string,
+  payloadFiles: readonly DeliveryFileRecord[],
+  media: Record<DemoAspect, ValidatedMediaArtifact>,
+  findings: PrivacyFinding[],
+): Promise<DeliveryFileRecord[]> {
+  const manifestFile = await loadRequiredFile(artifactDir, 'manifest.json');
+  const sumsFile = await loadRequiredFile(artifactDir, 'SHA256SUMS');
+  const manifestText = manifestFile.bytes.toString('utf8');
+  findings.push(...scanSensitiveText(manifestText, 'manifest.json'));
+  findings.push(...scanSensitiveText('manifest.json\nSHA256SUMS', 'integrity-filenames'));
+
+  const manifest = parseManifest(manifestText);
+  assertManifestMatches(manifest, payloadFiles, media);
+
+  const sums = parseSha256Sums(sumsFile.bytes.toString('utf8'));
+  const actualRecords = [...payloadFiles, fileRecord(manifestFile)];
+  if (sums.size !== actualRecords.length) {
+    throw new Error('SHA256SUMS 校验和条目数量与交付文件不一致');
+  }
+  for (const record of actualRecords) {
+    if (sums.get(record.relativePath) !== record.sha256) {
+      throw new Error(`SHA-256 校验和失败：${record.relativePath}`);
+    }
+  }
+  return [fileRecord(manifestFile), fileRecord(sumsFile)];
+}
+
+/**
+ * 验证完整产品演示交付目录。
+ *
+ * 关键帧必须由调用方注入真实自动 OCR 引擎；未接线、不可用或证据不完整都会阻断交付。
+ * `ocrTextFiles` 保留用于扫描额外的既有 OCR 文本，不能替代 42 张关键帧的自动 OCR。
+ */
+export async function validateDelivery(
+  options: ValidateDeliveryOptions,
+): Promise<DeliveryValidationResult> {
+  assertNonEmptyString(options.artifactDir, '产物目录');
+  const artifactInfo = await stat(options.artifactDir).catch((error: unknown) => {
+    throw new Error(`产物目录不存在：${error instanceof Error ? error.message : String(error)}`);
+  });
+  if (!artifactInfo.isDirectory()) throw new Error('产物目录必须是目录');
+
+  const logFiles = uniquePaths(options.logFiles, 'Playwright 控制台或网络日志');
+  const markdownFiles = uniquePaths(options.markdownFiles, '虚拟导出 Markdown');
+  const ocrTextFiles = optionalUniquePaths(options.ocrTextFiles, '既有 OCR 文本');
+  const sourceTextFiles = uniquePaths(options.sourceTextFiles ?? [], '源码或 HTML 文本');
+  const privacyObjects = options.privacyObjects ?? [];
+  if (privacyObjects.length === 0) {
+    throw new Error('交付验证必须提供至少一个演示夹具或隐私扫描对象');
+  }
+  const probeMediaFile = options.probeMediaFile ?? ((filePath: string) => probeMedia(filePath));
+
+  const loadedByPath = new Map<string, LoadedFile>();
+  const load = async (relativePath: string): Promise<LoadedFile> => {
+    const existing = loadedByPath.get(relativePath);
+    if (existing) return existing;
+    const loaded = await loadRequiredFile(options.artifactDir, relativePath);
+    loadedByPath.set(relativePath, loaded);
+    return loaded;
+  };
+
+  const media = {} as Record<DemoAspect, ValidatedMediaArtifact>;
+  for (const aspect of ['16x9', '9x16'] as const) {
+    const relativePath = MEDIA_FILES[aspect];
+    const file = await load(relativePath);
+    media[aspect] = validateMediaArtifact({
+      aspect,
+      relativePath,
+      sizeBytes: file.sizeBytes,
+      probe: await probeMediaFile(file.absolutePath),
+    });
+  }
+
+  const subtitles: Record<string, ValidatedSubtitleArtifact> = {};
+  let sharedTimeline: ReadonlyArray<readonly [number, number]> | null = null;
+  for (const relativePath of SUBTITLE_FILES) {
+    const file = await load(relativePath);
+    const validation = validateSubtitleArtifact(file.bytes.toString('utf8'), relativePath);
+    if (sharedTimeline && !sameTimeline(sharedTimeline, validation.timelineMilliseconds)) {
+      throw new Error(`三个 SRT 的时间轴必须一致，检测到漂移：${relativePath}`);
+    }
+    sharedTimeline ??= validation.timelineMilliseconds;
+    subtitles[relativePath] = validation;
+  }
+
+  const covers = {} as Record<DemoAspect, { width: number; height: number }>;
+  for (const aspect of ['16x9', '9x16'] as const) {
+    const relativePath = COVER_FILES[aspect];
+    const file = await load(relativePath);
+    covers[aspect] = validateCoverArtifact(file.bytes, aspect, relativePath);
+  }
+
+  if (!options.runKeyframeOcr) {
+    throw new Error('交付验证未接线自动 OCR；必须对横竖屏七镜头的 start/action/end 关键帧执行真实 OCR');
+  }
+  const keyframeFrames: KeyframeOcrFrame[] = [];
+  for (const descriptor of expectedKeyframeDescriptors()) {
+    const file = await load(descriptor.relativePath);
+    keyframeFrames.push({
+      ...descriptor,
+      absolutePath: file.absolutePath,
+      imageBytes: file.bytes,
+    });
+  }
+  let rawOcrResult: KeyframeOcrRunResult;
+  try {
+    rawOcrResult = await options.runKeyframeOcr(keyframeFrames);
+  } catch (error) {
+    throw new Error(
+      `自动 OCR 执行失败，交付已阻断：${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const keyframeOcr = assertKeyframeOcrEvidence(rawOcrResult, keyframeFrames);
+
+  const textPaths = [...new Set([
+    ...SUBTITLE_FILES,
+    ...logFiles,
+    ...markdownFiles,
+    ...sourceTextFiles,
+    ...ocrTextFiles,
+  ])];
+  const findings: PrivacyFinding[] = [];
+  for (const relativePath of textPaths) {
+    const file = await load(relativePath);
+    findings.push(...scanSensitiveText(file.bytes.toString('utf8'), relativePath));
+    findings.push(...scanSensitiveText(relativePath, 'delivery-filename'));
+  }
+  for (const relativePath of [...Object.values(MEDIA_FILES), ...Object.values(COVER_FILES)]) {
+    findings.push(...scanSensitiveText(relativePath, 'delivery-filename'));
+  }
+  for (const evidence of keyframeOcr.evidence) {
+    findings.push(...scanSensitiveText(evidence.text, `关键帧 OCR:${evidence.relativePath}`));
+  }
+  for (const object of privacyObjects) {
+    findings.push(...scanDemoObject(object.value, object.source));
+  }
+
+  let files = [...loadedByPath.values()].map(fileRecord);
+  let integrityVerified = false;
+  if (options.requireIntegrityFiles) {
+    const integrityFiles = await verifyIntegrityFiles(options.artifactDir, files, media, findings);
+    files = [...files, ...integrityFiles];
+    integrityVerified = true;
+  }
+
+  assertNoSensitiveContent(findings);
+  files.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+
+  return {
+    artifactDir: path.resolve(options.artifactDir),
+    files,
+    media,
+    subtitles,
+    covers,
+    subtitleTimelineMilliseconds: sharedTimeline ?? [],
+    manualChecks: [],
+    keyframeOcr: {
+      engine: keyframeOcr.engine,
+      evidenceCount: keyframeOcr.evidence.length,
+    },
+    integrityVerified,
+  };
+}
+
+async function writeAtomically(filePath: string, content: string): Promise<void> {
+  const temporaryPath = `${filePath}.tmp-${randomUUID()}`;
+  let temporaryCreated = false;
+  let temporaryFile: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    temporaryFile = await open(temporaryPath, 'wx');
+    temporaryCreated = true;
+    await temporaryFile.writeFile(content, 'utf8');
+    await temporaryFile.close();
+    temporaryFile = undefined;
+    await rename(temporaryPath, filePath);
+  } catch (error) {
+    const cleanupErrors: unknown[] = [];
+    if (temporaryFile) {
+      try {
+        await temporaryFile.close();
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
+    }
+    if (temporaryCreated) {
+      try {
+        await unlink(temporaryPath);
+      } catch (cleanupError) {
+        if ((cleanupError as NodeJS.ErrnoException).code !== 'ENOENT') {
+          cleanupErrors.push(cleanupError);
+        }
+      }
+    }
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(
+        [error, ...cleanupErrors],
+        `原子写入 ${filePath} 失败，且无法完整清理临时资源`,
+      );
+    }
+    throw error;
+  }
+}
+
+/** 写入 manifest.json 和覆盖全部载荷文件及清单本身的 SHA256SUMS。 */
+export async function writeManifest(options: WriteManifestOptions): Promise<WrittenManifestPaths> {
+  const manifest = buildDeliveryManifest({
+    version: options.version,
+    builtAt: options.builtAt,
+    gitCommit: options.gitCommit,
+    media: options.validation.media,
+    files: options.validation.files.filter(
+      (file) => file.relativePath !== 'manifest.json' && file.relativePath !== 'SHA256SUMS',
+    ),
+    manualChecks: options.validation.manualChecks,
+  });
+  const manifestContent = `${JSON.stringify(manifest, null, 2)}\n`;
+  assertNoSensitiveContent(scanSensitiveText(manifestContent, 'manifest.json'));
+
+  const manifestPath = resolveArtifactPath(options.artifactDir, 'manifest.json');
+  const sha256SumsPath = resolveArtifactPath(options.artifactDir, 'SHA256SUMS');
+  await writeAtomically(manifestPath, manifestContent);
+
+  const manifestRecord: DeliveryFileRecord = {
+    relativePath: 'manifest.json',
+    sizeBytes: Buffer.byteLength(manifestContent),
+    sha256: sha256Hex(manifestContent),
+  };
+  const payloadRecords = manifest.files.map((file) => ({
+    relativePath: file.relativePath,
+    sha256: file.sha256,
+  }));
+  await writeAtomically(
+    sha256SumsPath,
+    formatSha256Sums([...payloadRecords, manifestRecord]),
+  );
+
+  return { manifestPath, sha256SumsPath };
+}

--- a/src/TypeScriptMigration.test.ts
+++ b/src/TypeScriptMigration.test.ts
@@ -212,7 +212,7 @@ test('全部第一方前端测试应迁移到 TypeScript', async () => {
   const typeScriptTests = testFiles.filter((path) => path.endsWith('.test.ts'));
 
   assert.deepEqual(legacyTests, []);
-  assert.equal(typeScriptTests.length, 115);
+  assert.ok(typeScriptTests.length >= 115, `TypeScript 测试数量意外回退：${typeScriptTests.length}`);
 });
 
 test('全部第一方 Node 工具脚本应迁移到 TypeScript', async () => {


### PR DESCRIPTION
## 概要

- 实现 85 秒 Work Review 产品演示视频的完整生成流水线
- 输出横屏 1920×1080 与竖屏 1080×1920 独立构图
- 展示同一助手会话中的基础模板与演示 AI
- 生成中英双语硬字幕、三份 SRT、封面、manifest 与 SHA256SUMS
- 增加真实 macOS Vision OCR 隐私门禁与媒体规格验收
- 不修改 README，生成产物保持 Git 忽略

## 验证

- `npm run demo:check`：146/146 通过
- `npm run demo:validate`：通过（真实 macOS Vision OCR）
- `npm run verify:frontend`：通过
- `npm run check`：0 errors / 0 warnings
- `git diff --check`：通过
- SHA256SUMS：全部通过
- 两套视频完整解码：通过
- 85.000 秒、30fps CFR、2550 帧、H.264/AAC/yuv420p
- 48kHz 立体声，-14.0 LUFS-I，True Peak -1.2 dBFS

## 审计

- 最终代码审计：无 Critical / Important
- 最终媒体审计：无阻断问题
